### PR TITLE
Fix nproc call in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,20 +29,21 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 # Invoke a command to determine how many CPU cores we have, and set
 # NUM_MAKE_PROCESSES accordingly so we know what number to pass to make -j.
 if(APPLE)
-   set (PROCESSOR_COUNT_COMMAND "sysctl -n hw.physicalcpu")
+   set (PROCESSOR_COUNT_COMMAND sysctl -n hw.physicalcpu)
 else()
-   set (PROCESSOR_COUNT_COMMAND "nproc")
+   set (PROCESSOR_COUNT_COMMAND nproc)
 endif()
 
 execute_process(
     COMMAND ${PROCESSOR_COUNT_COMMAND}
     RESULT_VARIABLE NPROC_RESULT
-    OUTPUT_VARIABLE NPROC_OUT
+    OUTPUT_VARIABLE NUM_MAKE_PROCESSES
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 # Default to four jobs if the command fails.
 if(NPROC_RESULT)
+    message (WARNING "Unable to detect number of processors. Building nGraph with make -j4.")
     set(NUM_MAKE_PROCESSES 4)
 endif()
 


### PR DESCRIPTION
Turns out that `$(nproc)` doesn't do in CMake what it does in the shell.