### PR TITLE
Force CI builds to use pre-built llvm

### DIFF
--- a/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
@@ -180,7 +180,7 @@ cd "${bridge_dir}"
 
 mkdir "${bbuild_dir}"
 cd "${bbuild_dir}"
-cmake ..
+cmake -DNGRAPH_USE_PREBUILT_LLVM=TRUE ..
 make -j16
 
 xtime="$(date)"


### PR DESCRIPTION
Force CI builds to use pre-built llvm, for speed.  Overall builds of tensorflow and ngraph-tf now take about 25 minutes.