### PR TITLE
using pre-commit for hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: autopep8
+        name: autopep8
+        entry: autopep8 -i
+        language: system
+        files: ^test/python/
+        types: [python]
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        files: ^test/python/
+        types: [python]
+    -   id: clang-format
+        name: clang-format
+        entry: clang-format --style=file -i
+        language: system
+        types: [c++]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+test/python/.pylintrc

--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ We welcome community contributions to nGraph. If you have an idea of how
 to improve the library:
 
 * Share your proposal via [GitHub issues].
+* Make sure your patch is in line with Google style by setting up your git `pre-commit` hooks.  First, ensure `clang-format` is in your path, then:
+
+   ```
+   pip install pre-commit autopep8 pylint
+   pre-commit install
+   ```
+
 * Ensure you can build the product and run all the examples with your patch.
 * In the case of a larger feature, create a test.
 * Submit a [pull request].


### PR DESCRIPTION
Forces `clang-format`, `autopep8`, and `pylint` checks on commits.

This requires developers to `pip install pre-commit` and `pre-commit install`, because, sadly, hooks cannot be directly baked into the repository.  They could be validated with a `pre-receive` hook on the server-side, but that requires GitHub Enterprise which we don't have, so we have to rely on an honor system.

Note that currently `master` fails all checks.  A commit to fix all style would be a good idea.