### PR TITLE
Enable resnet50 inference validation check in ngraph-tf CI

### DIFF
--- a/test/ci/docker/docker-run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-build.sh
@@ -51,9 +51,9 @@ volume_mounts='-v /dataset:/dataset'
 volume_mounts="${volume_mounts} -v ${bridge_dir}:${bridge_mountpoint}"
 volume_mounts="${volume_mounts} -v ${tf_dir}:${tf_mountpoint}"
 if [ -z "${NG_TF_TRAINED}" ] ; then
-  volume_mounts="${volume_mounts} -v /aipg_trained_dataset:/aipg_trained_dataset"
+  volume_mounts="${volume_mounts} -v /trained_dataset:/trained_dataset"
 else
-  volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/aipg_trained_dataset"
+  volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/trained_dataset"
 fi
 
 set -u  # No unset variables after this point
@@ -80,8 +80,6 @@ fi
 docker run --rm \
        --env RUN_UID="$(id -u)" \
        --env RUN_CMD="${BUILD_SCRIPT}" \
-       --env NGRAPH_IMAGENET_DATASET="${NGRAPH_IMAGENET_DATASET+}" \
-       --env NGRAPH_TRAINED_MODEL="${NGRAPH_TRAINED_MODEL+}" \
        ${DOCKER_HTTP_PROXY} ${DOCKER_HTTPS_PROXY} \
        ${volume_mounts} \
        "${IMAGE_CLASS}:${IMAGE_ID}" "${RUNASUSER_SCRIPT}"

--- a/test/ci/docker/docker-run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-build.sh
@@ -53,7 +53,8 @@ volume_mounts="${volume_mounts} -v ${tf_dir}:${tf_mountpoint}"
 if [ -z "${NG_TF_TRAINED}" ] ; then
   volume_mounts="${volume_mounts} -v /trained_dataset:/trained_dataset"
 else
-  volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/trained_dataset"
+  trained_abspath="$(realpath ${NG_TF_TRAINED})"
+  volume_mounts="${volume_mounts} -v ${trained_abspath}:/trained_dataset"
 fi
 
 set -u  # No unset variables after this point

--- a/test/ci/docker/docker-run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-build.sh
@@ -80,8 +80,8 @@ fi
 docker run --rm \
        --env RUN_UID="$(id -u)" \
        --env RUN_CMD="${BUILD_SCRIPT}" \
-       --env NGRAPH_IMAGENET_DATASET="${NGRAPH_IMAGENET_DATASET}" \
-       --env NGRAPH_TRAINED_MODEL="${NGRAPH_TRAINED_MODEL}" \
+       --env NGRAPH_IMAGENET_DATASET="${NGRAPH_IMAGENET_DATASET+}" \
+       --env NGRAPH_TRAINED_MODEL="${NGRAPH_TRAINED_MODEL+}" \
        ${DOCKER_HTTP_PROXY} ${DOCKER_HTTPS_PROXY} \
        ${volume_mounts} \
        "${IMAGE_CLASS}:${IMAGE_ID}" "${RUNASUSER_SCRIPT}"

--- a/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
@@ -73,7 +73,9 @@ volume_mounts=''
 if [ ! -z "${NG_TF_MODELS_REPO}" ] ; then
   volume_mounts="${volume_mounts} -v ${NG_TF_MODELS_REPO}:/home/dockuser/ngraph-models"
 fi
-if [ ! -z "${NG_TF_TRAINED}" ] ; then
+if [ -z "${NG_TF_TRAINED}" ] ; then
+  volume_mounts="${volume_mounts} -v /aipg_trained_dataset:/aipg_trained_dataset"
+else
   volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/aipg_trained_dataset"
 fi
 

--- a/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
@@ -39,12 +39,15 @@ bbuild_dir="${bridge_dir}/BUILD-BRIDGE"
 tf_dir='/home/dockuser/tensorflow'
 ci_dir="${bridge_dir}/test/ci/docker"
 dataset_dir='/dataset'
+trained_dir='/trained_dataset'
 venv_dir="/tmp/venv_python${PYTHON_VERSION_NUMBER}"
 ngraph_dist_dir="${bbuild_dir}/ngraph/ngraph_dist"
 ngraph_wheel_dir="${bbuild_dir}/python/dist"
 libngraph_so="${bbuild_dir}/src/libngraph_device.so"
 libngraph_dist_dir="${bridge_dir}/libngraph_dist"  # Directory to save plugin artifacts in
 libngraph_tarball="${bridge_dir}/libngraph_dist.tgz"  # Tarball artifact to send to Artifactory
+imagenet_dataset="${dataset_dir}/Imagenet_Validation"
+trained_resnet50_model="${trained_dir}/ngraph_tensorflow/fully_trained/resnet50"
 
 # HOME is expected to be /home/dockuser.  See script run-as-user.sh, which
 # sets this up.
@@ -60,12 +63,15 @@ echo "  bbuild_dir=${bbuild_dir}"
 echo "  tf_dir=${tf_dir}"
 echo "  ci_dir=${ci_dir}"
 echo "  dataset_dir=${dataset_dir}"
+echo "  trained_dir=${trained_dir}"
 echo "  venv_dir=${venv_dir}"
 echo "  ngraph_dist_dir=${ngraph_dist_dir}"
 echo "  ngraph_wheel_dir=${ngraph_wheel_dir}"
 echo "  libngraph_so=${libngraph_so}"
 echo "  libngraph_dist_dir=${libngraph_dist_dir}"
 echo "  libngraph_tarball=${libngraph_tarball}"
+echo "  imagenet_dataset=${imagenet_dataset}"
+echo "  trained_resnet50_model=${trained_resnet50_model}"
 echo ''
 echo "  HOME=${HOME}"
 echo "  PYTHON_VERSION_NUMBER=${PYTHON_VERSION_NUMBER}"
@@ -111,15 +117,15 @@ if [ ! -d "${dataset_dir}" ] ; then
     exit 1
 fi
 
-if [ ! -d "${NGRAPH_IMAGENET_DATASET}" ] ; then
+if [ ! -d "${imagenet_dataset}" ] ; then
     ( >&2 echo '***** Error: *****' )
-    ( >&2 echo "The validation dataset for ImageNet does not seem to be found: ${NGRAPH_IMAGENET_DATASET}" )
+    ( >&2 echo "The validation dataset for ImageNet does not seem to be found: ${imagenet_dataset}" )
     exit 1
 fi
 
-if [ ! -d "${NGRAPH_TRAINED_MODEL}" ] ; then
+if [ ! -d "${trained_resnet50_model}" ] ; then
     ( >&2 echo '***** Error: *****' )
-    ( >&2 echo "The pretrained model for resnet50 CI testing does not seem to be found: ${NGRAPH_TRAINED_MODEL}" )
+    ( >&2 echo "The pretrained model for resnet50 CI testing does not seem to be found: ${trained_resnet50_model}" )
     exit 1
 fi
 
@@ -274,6 +280,8 @@ echo  "===== Run Bridge CI Test Scripts at ${xtime} ====="
 echo  ' '
 
 cd "${bbuild_dir}/test"
+export NGRAPH_IMAGENET_DATASET="${imagenet_dataset}"
+export NGRAPH_TRAINED_MODEL="${trained_resnet50_model}"
 "${bridge_dir}/test/ci/run-premerge-ci-checks.sh"
 
 xtime="$(date)"

--- a/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
@@ -38,6 +38,7 @@ bridge_dir='/home/dockuser/ngraph-tf'
 bbuild_dir="${bridge_dir}/BUILD-BRIDGE"
 tf_dir='/home/dockuser/tensorflow'
 ci_dir="${bridge_dir}/test/ci/docker"
+dataset_dir='/dataset'
 venv_dir="/tmp/venv_python${PYTHON_VERSION_NUMBER}"
 ngraph_dist_dir="${bbuild_dir}/ngraph/ngraph_dist"
 ngraph_wheel_dir="${bbuild_dir}/python/dist"
@@ -58,6 +59,7 @@ echo "  bridge_dir=${bridge_dir}"
 echo "  bbuild_dir=${bbuild_dir}"
 echo "  tf_dir=${tf_dir}"
 echo "  ci_dir=${ci_dir}"
+echo "  dataset_dir=${dataset_dir}"
 echo "  venv_dir=${venv_dir}"
 echo "  ngraph_dist_dir=${ngraph_dist_dir}"
 echo "  ngraph_wheel_dir=${ngraph_wheel_dir}"
@@ -100,6 +102,24 @@ fi
 if [ -f "${libngraph_tarball}" ] ; then
     ( >&2 echo '***** Error: *****' )
     ( >&2 echo "libngraph distribution directory already exists -- please remove it before calling this script: ${libngraph_tarball}" )
+    exit 1
+fi
+
+if [ ! -d "${dataset_dir}" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "Datset directory ${dataset_dir} does not seem to be mounted inside the Docker container" )
+    exit 1
+fi
+
+if [ ! -d "${NGRAPH_IMAGENET_DATASET}" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "The validation dataset for ImageNet does not seem to be found: ${NGRAPH_IMAGENET_DATASET}" )
+    exit 1
+fi
+
+if [ ! -d "${NGRAPH_TRAINED_MODEL}" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "The pretrained model for resnet50 CI testing does not seem to be found: ${NGRAPH_TRAINED_MODEL}" )
     exit 1
 fi
 

--- a/test/ci/run-premerge-ci-checks.sh
+++ b/test/ci/run-premerge-ci-checks.sh
@@ -17,6 +17,14 @@ if [ ! -e $TF_ROOT ]; then
     exit 1
 fi
 
+# Define default dataset and trained model directories, if not already set
+if [ -z ${NGRAPH_IMAGENET_DATASET+x} ]; then
+    NGRAPH_IMAGENET_DATASET='/mnt/data/Imagenet_Validation/'
+fi
+if [ -z ${NGRAPH_TRAINED_MODEL+x} ]; then
+    NGRAPH_TRAINED_MODEL='/nfs/fm/disks/aipg_trained_dataset/ngraph_tensorflow/fully_trained/resnet50'
+fi
+
 #===============================================================================
 # Run the test...
 #===============================================================================
@@ -30,17 +38,12 @@ pushd python
 python -m pytest
 popd
 
-# Temporarily disabled, as per discussion in standup with Avijit, since the
-# dataset is only available on NFS, which won't work in Docker containers or
-# when testing in the cloud.
-echo "Inference test disabled for now -- see comments in script."
-
-# echo "Running a quick inference test"
-# pushd ../../examples/resnet
-# python tf_cnn_benchmarks.py --model=resnet50 --eval --num_inter_threads=1 \
-#   --batch_size=128 --num_batches=50 \
-#   --train_dir /nfs/fm/disks/aipg_trained_dataset/ngraph_tensorflow/fully_trained/resnet50\
-#   --data_format NCHW --select_device NGRAPH \
-#   --data_name=imagenet --data_dir /mnt/data/TF_ImageNet_latest/ --datasets_use_prefetch=False
-# popd
+echo "Running a quick inference test"
+pushd ../../examples/resnet
+python tf_cnn_benchmarks.py --model=resnet50 --eval --num_inter_threads=1 \
+  --batch_size=128 --num_batches=50 \
+  --train_dir "${NGRAPH_TRAINED_MODEL}" \
+  --data_format NCHW --select_device NGRAPH \
+  --data_name=imagenet --data_dir "${NGRAPH_IMAGENET_DATASET}" --datasets_use_prefetch=False
+popd
 


### PR DESCRIPTION
There was a short resnet50 inference validation test in ngraph-tf continuous integration testing. I had to turn it off when I automated CI because there were problems running it with the new "import ngraph" syntax and the large ImageNet dataset could not easily be stored on /dataset.

This PR restores the resnet50 inference validation test in automated CI. Part of this was achieved by changing the dataset used to a smaller 6 gig version of ImageNet.

This PR has a sibling in the cje-algo repo. The whole change is tricky to put in place, as the cje-algo portion must be merged to master before the ngraph-tf portion, in order to avoid breaking production CI for ngraph-tf.  Both the ngraph-tf-unittest and ngraph-tf-daily-build jobs are affected, and must each be tested.

Successful testing of this PR for ngraph-tf-unittest:

cje-algo: branch chrisl/enable-resnet50-in-ci, ngraph-tf: branch master
https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-unittest/194/

cje-algo: branch chrisl/enable-resnet50-in-ci, ngraph-tf: branch chrisl/enable-resnet50-in-ci
https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-unittest/193/

Successful testing of this PR for ngraph-tf-daily-build:

cje-algo: branch chrisl/enable-resnet50-in-ci, ngraph-tf: branch master
https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/145/

cje-algo: branch chrisl/enable-resnet50-in-ci, ngraph-tf: branch chrisl/enable-resnet50-in-ci
https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/144/