### PR TITLE
Reinstate /dataset in docker container for running commands

### DIFF
--- a/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
@@ -69,14 +69,16 @@ IMAGE_CLASS='ngraph_tf_ci'
 # IMAGE_ID set from 1st parameter, above
 
 # Set up optional volume mounts
-volume_mounts=''
+volume_mounts='-v /dataset:/dataset'
 if [ ! -z "${NG_TF_MODELS_REPO}" ] ; then
   volume_mounts="${volume_mounts} -v ${NG_TF_MODELS_REPO}:/home/dockuser/ngraph-models"
 fi
 if [ -z "${NG_TF_TRAINED}" ] ; then
   volume_mounts="${volume_mounts} -v /aipg_trained_dataset:/aipg_trained_dataset"
+  volume_mounts="${volume_mounts} -v /aipg_trained_dataset:/trained_dataset"
 else
   volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/aipg_trained_dataset"
+  volume_mounts="${volume_mounts} -v ${NG_TF_TRAINED}:/trained_dataset"
 fi
 
 # Set up optional environment variables


### PR DESCRIPTION
Reinstate /dataset in docker container for running commands.  It appears to have been lost when porting the script from ngraph-tensorflow-bridge to ngraph-tf. This is needed for running new inference models which use real datasets (instead of synthetic) that are located in /dataset .

Also, mount aipg_trained_dataset at both /aipg_trained_dataset and /trained_dataset in the container.  This provides backwards compatibility for existing run-model jobs, while also standardizing on the /trained_dataset name.  Note that I checked with Nick that doing this host mounted-in-two-places is OK, and we both think it will work.
