### PR TITLE
ngraph-tf repo-side automation for tensorflow-with-ngraph wheels (for r0.4)

### DIFF
--- a/test/ci/docker/Dockerfile.ngraph-tf-ci
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci
@@ -63,8 +63,8 @@ RUN pip install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 #
 # This bazel version works with current TF
-RUN wget -c https://github.com/bazelbuild/bazel/releases/download/0.11.0/bazel_0.11.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.11.0-linux-x86_64.deb || true
+RUN wget -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test/ci/docker/docker-run-tf-with-ngraph-build.sh
+++ b/test/ci/docker/docker-run-tf-with-ngraph-build.sh
@@ -39,14 +39,25 @@ if [ -z "${IMAGE_ID}" ] ; then
     exit 1
 fi
 
-set -u  # No unset variables after this point
-
 # Find the top-level bridge directory, so we can mount it into the docker
 # container
 bridge_dir="$(realpath ../../..)"
 
 bridge_mountpoint='/home/dockuser/ngraph-tf'
 tf_mountpoint='/home/dockuser/tensorflow'
+
+# Set up a bunch of volume mounts
+volume_mounts='-v /dataset:/dataset'
+volume_mounts="${volume_mounts} -v ${bridge_dir}:${bridge_mountpoint}"
+volume_mounts="${volume_mounts} -v ${tf_dir}:${tf_mountpoint}"
+if [ -z "${NG_TF_TRAINED}" ] ; then
+  volume_mounts="${volume_mounts} -v /trained_dataset:/trained_dataset"
+else
+  trained_abspath="$(realpath ${NG_TF_TRAINED})"
+  volume_mounts="${volume_mounts} -v ${trained_abspath}:/trained_dataset"
+fi
+
+set -u  # No unset variables after this point
 
 RUNASUSER_SCRIPT="${bridge_mountpoint}/test/ci/docker/docker-scripts/run-as-user.sh"
 BUILD_SCRIPT="${bridge_mountpoint}/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh"
@@ -71,8 +82,7 @@ docker run --rm \
        --env RUN_UID="$(id -u)" \
        --env RUN_CMD="${BUILD_SCRIPT}" \
        ${DOCKER_HTTP_PROXY} ${DOCKER_HTTPS_PROXY} \
-       -v "${bridge_dir}:${bridge_mountpoint}" \
-       -v "${tf_dir}:${tf_mountpoint}" \
+       ${volume_mounts} \
        "${IMAGE_CLASS}:${IMAGE_ID}" "${RUNASUSER_SCRIPT}"
 
 

--- a/test/ci/docker/docker-run-tf-with-ngraph-build.sh
+++ b/test/ci/docker/docker-run-tf-with-ngraph-build.sh
@@ -1,0 +1,78 @@
+#!  /bin/bash
+
+# ==============================================================================
+#  Copyright 2018 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ==============================================================================
+
+# Script parameters:
+#
+# $1 ImageID    Required: ID of the ngtf_bridge_ci docker image to use
+# $2 TFdir      Required: tensorflow directory to build
+
+set -e  # Fail on any command with non-zero exit
+
+tf_dir="${2}"
+if [ ! -d "${tf_dir}" ] ; then
+    echo 'Please provide the name of the tensorflow directory you want to build, as the 2nd parameter'
+    exit 1
+fi
+
+# Note that the docker image must have been previously built using the
+# make-docker-ngraph-tf-ci.sh script (in the same directory as this script).
+#
+IMAGE_CLASS='ngraph_tf_ci'
+IMAGE_ID="${1}"
+if [ -z "${IMAGE_ID}" ] ; then
+    echo 'Please provide an image version as the first parameter'
+    exit 1
+fi
+
+set -u  # No unset variables after this point
+
+# Find the top-level bridge directory, so we can mount it into the docker
+# container
+bridge_dir="$(realpath ../../..)"
+
+bridge_mountpoint='/home/dockuser/ngraph-tf'
+tf_mountpoint='/home/dockuser/tensorflow'
+
+RUNASUSER_SCRIPT="${bridge_mountpoint}/test/ci/docker/docker-scripts/run-as-user.sh"
+BUILD_SCRIPT="${bridge_mountpoint}/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh"
+
+# If proxy settings are detected in the environment, make sure they are
+# included on the docker-build command-line.  This mirrors a similar system
+# in the Makefile.
+
+if [ ! -z "${http_proxy}" ] ; then
+    DOCKER_HTTP_PROXY="--env http_proxy=${http_proxy}"
+else
+    DOCKER_HTTP_PROXY=' '
+fi
+
+if [ ! -z "${https_proxy}" ] ; then
+    DOCKER_HTTPS_PROXY="--env https_proxy=${https_proxy}"
+else
+    DOCKER_HTTPS_PROXY=' '
+fi
+
+docker run --rm \
+       --env RUN_UID="$(id -u)" \
+       --env RUN_CMD="${BUILD_SCRIPT}" \
+       ${DOCKER_HTTP_PROXY} ${DOCKER_HTTPS_PROXY} \
+       -v "${bridge_dir}:${bridge_mountpoint}" \
+       -v "${tf_dir}:${tf_mountpoint}" \
+       "${IMAGE_CLASS}:${IMAGE_ID}" "${RUNASUSER_SCRIPT}"
+
+

--- a/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
+++ b/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
@@ -175,7 +175,7 @@ source "${venv_dir}/bin/activate"
 
 xtime="$(date)"
 echo  ' '
-echo  "===== Installing TensorFlow Wheel at ${xtime} ====="
+echo  "===== Installing TensorFlow-nGraph Wheel at ${xtime} ====="
 echo  ' '
 
 set -x
@@ -203,7 +203,7 @@ python -c 'import tensorflow as tf;  hello = tf.constant("Hello world!"); sess =
 
 xtime="$(date)"
 echo  ' '
-echo  "===== Run TensorFlow Unit-Tests at ${xtime} ====="
+echo  "===== Run TensorFlow-nGraph Unit-Tests at ${xtime} ====="
 echo  ' '
 
 cd "${tf_dir}"

--- a/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
+++ b/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
@@ -1,0 +1,214 @@
+#!  /bin/bash
+
+# ==============================================================================
+#  Copyright 2018 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ==============================================================================
+
+# This script is designed to be called from within a docker container.
+# It is installed into a docker image.  It will not run outside the container.
+
+set -e  # Make sure we exit on any command that returns non-zero
+set -u  # No unset variables
+set -o pipefail # Make sure cmds in pipe that are non-zero also fail immediately
+
+
+# FUTURE: enable python 3, with selection via PYTHON_VERSION_NUMBER
+#if [ -z "${PYTHON_VERSION_NUMBER:-}" ] ; then
+#    ( >&2 echo "Env. variable PYTHON_VERSION_NUMBER has not been set" )
+#    exit 1
+#fi
+PYTHON_VERSION_NUMBER=2
+export PYTHON_BIN_PATH="/usr/bin/python$PYTHON_VERSION_NUMBER"
+
+
+# Set up some important known directories
+bridge_dir='/home/dockuser/bridge'
+tf_dir='/home/dockuser/tensorflow'
+ci_dir="${bridge_dir}/test/ci/docker"
+venv_dir="/tmp/venv_python${PYTHON_VERSION_NUMBER}"
+
+# These will be dynamically defined below
+tf_orig_whl='UNDEFINED'
+tf_w_ngraph_whl='UNDEFINED'
+
+# HOME is expected to be /home/dockuser.  See script run-as-user.sh, which
+# sets this up.
+
+# Set up a directory to build the wheel in, so we know where to grab
+# the wheel from later.  If the directory already exists, remove it.
+export WHEEL_BUILD_DIR="${tf_dir}/BUILD_WHEEL"
+
+echo "In $(basename ${0}):"
+echo ''
+echo "  bridge_dir=${bridge_dir}"
+echo "  tf_dir=${tf_dir}"
+echo "  ci_dir=${ci_dir}"
+echo "  venv_dir=${venv_dir}"
+echo ''
+echo "  HOME=${HOME}"
+echo "  PYTHON_VERSION_NUMBER=${PYTHON_VERSION_NUMBER}"
+echo "  PYTHON_BIN_PATH=${PYTHON_BIN_PATH}"
+echo "  WHEEL_BUILD_DIR=${WHEEL_BUILD_DIR}  (Used by maint/build-install-tf.sh)"
+
+# Do some up-front checks, to make sure necessary directories are in-place and
+# build directories are not-in-place
+
+if [ -d "${WHEEL_BUILD_DIR}" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "Wheel build directory already exists -- please remove it before calling this script: ${WHEEL_BUILD_DIR}" )
+    exit 1
+fi
+
+if [ -d "${venv_dir}" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "Virtual-env build directory already exists -- please remove it before calling this script: ${venv_dir}" )
+    exit 1
+fi
+
+# Make sure the Bazel cache is in /tmp, as docker images have too little space
+# in the root filesystem, where /home (and $HOME/.cache) is.  Even though we
+# may not be using the Bazel cache in the builds (in docker), we do this anyway
+# in case we decide to turn the Bazel cache back on.
+echo "Adjusting bazel cache to be located in /tmp/bazel-cache"
+rm -fr "$HOME/.cache"
+mkdir /tmp/bazel-cache
+ln -s /tmp/bazel-cache "$HOME/.cache"
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Configuring TensorFlow-nGraph Build at ${xtime} ====="
+echo  ' '
+
+export CC_OPT_FLAGS="-march=native"
+export USE_DEFAULT_PYTHON_LIB_PATH=1
+
+export TF_NEED_NGRAPH=1
+
+export TF_ENABLE_XLA=0
+
+export TF_NEED_MKL=1
+export TF_DOWNLOAD_MKL=1
+
+export TF_NEED_JEMALLOC=1
+export TF_NEED_GCP=0
+export TF_NEED_HDFS=0
+export TF_NEED_VERBS=0
+export TF_NEED_OPENCL=0
+export TF_NEED_CUDA=0
+export TF_NEED_MPI=0
+
+cd "${tf_dir}"
+./configure
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Starting TensorFlow-nGraph Binaries Build at ${xtime} ====="
+echo  ' '
+
+cd "${tf_dir}"
+
+# Add flag --verbose_failures for tons of output
+bazel build --config=opt --config=mkl ${BAZEL_BUILD_EXTRA_FLAGS:-} //tensorflow/tools/pip_package:build_pip_package
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Starting TensorFlow-nGraph Wheel Build at ${xtime} ====="
+echo  ' '
+
+bazel-bin/tensorflow/tools/pip_package/build_pip_package "${WHEEL_BUILD_DIR}"
+
+tf_orig_whl="$(find "${WHEEL_BUILD_DIR}" -name '*.whl')"
+
+if [ -z "$tf_orig_whl" ] ; then
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "Did not find a wheel fine in: ${WHEEL_BUILD_DIR}" )
+    ( >&2 echo "Contents of wheel build directory ${WHEEL_BUILD_DIR}:")
+    ( >&2 ls -l "${WHEEL_BUILD_DIR}")
+    exit 1
+fi
+
+tf_w_ngraph_whl="$(echo $tf_orig_whl | sed -e 's/tensorflow-/tensorflow-ngraph-/')"
+
+echo ' '
+echo "Built wheel: $tf_orig_whl"
+echo "Renaming to: $tf_w_ngraph_whl"
+
+# Rename wheel file to indicate that it is a special tensorflow-with-ngraph
+# build
+if [ -f "${tf_orig_whl}" ] ; then
+    set -x
+    mv "${tf_orig_whl}" "${tf_w_ngraph_whl}"
+    set +x
+else
+    ( >&2 echo '***** Error: *****' )
+    ( >&2 echo "Expected TF wheel does not appear to have been built: ${WHEEL_BUILD_DIR}/${tf_orig_whl}" )
+    ( >&2 echo "Contents of wheel build directory ${WHEEL_BUILD_DIR}:")
+    ( >&2 ls -l "${WHEEL_BUILD_DIR}")
+    exit 1
+fi
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Setting Up Virtual Environment for TensorFlow-nGraph Wheel at ${xtime} ====="
+echo  ' '
+
+cd "${tf_dir}"
+
+# Make sure the bash shell prompt variables are set, as virtualenv crashes
+# if PS2 is not set.
+PS1='prompt> '
+PS2='prompt-more> '
+virtualenv --system-site-packages -p "${PYTHON_BIN_PATH}" "${venv_dir}"
+source "${venv_dir}/bin/activate"
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Installing TensorFlow Wheel at ${xtime} ====="
+echo  ' '
+
+set -x
+echo ' '
+echo 'Proxy settings in exports:'
+export | grep -i proxy
+echo ' '
+echo "Installing the following wheel: ${tf_w_ngraph_whl}"
+cd "${tf_dir}"
+# If installing into the OS, use:
+# sudo --preserve-env --set-home pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${tf_w_ngraph_whl}"
+# Here we are installing into a virtual environment, so DO NOT USE SUDO!!!
+pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${tf_w_ngraph_whl}"
+set +x
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Run Sanity Check for TensorFlow-nGraph at ${xtime} ====="
+echo  ' '
+
+# One cannot import tensorflow when in the top-level of the tensorflow source
+# directory, so let's use /tmp
+cd /tmp
+python -c 'import tensorflow as tf;  hello = tf.constant("Hello world!"); sess = tf.Session(); print(sess.run(hello))'
+
+xtime="$(date)"
+echo  ' '
+echo  "===== Deactivating the Virtual Environment at ${xtime} ====="
+echo  ' '
+
+deactivate
+
+xtime="$(date)"
+echo ' '
+echo "===== Completed TensorFlow-nGraph Build at ${xtime} ====="
+echo ' '

--- a/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
+++ b/test/ci/docker/docker-scripts/run-tf-with-ngraph-build.sh
@@ -203,6 +203,14 @@ python -c 'import tensorflow as tf;  hello = tf.constant("Hello world!"); sess =
 
 xtime="$(date)"
 echo  ' '
+echo  "===== Run TensorFlow Unit-Tests at ${xtime} ====="
+echo  ' '
+
+cd "${tf_dir}"
+bazel test @ngraph_tf//:ngraph_tf_tests
+
+xtime="$(date)"
+echo  ' '
 echo  "===== Deactivating the Virtual Environment at ${xtime} ====="
 echo  ' '
 


### PR DESCRIPTION
Add scripts to automate building of the TensorFlow + nGraph in the same wheel.  While the automation does the builds in a clone of the NervanaSystems/tensorflow repo (which is a fork of tensorflow/tensorflow, used for upstreaming), the automation scripts are kept in the ngraph-tf repo as they are specific to Intel's environment.

The wheel produced has a name like: tensorflow-ngraph-1.10.0rc1-cp27-cp27mu-linux_x86_64.whl

Also update the bazel version used in the Docker containers to 0.16.0.