### PR TITLE
Make clang-format check required for CI

### DIFF
--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -59,11 +59,11 @@ for ROOT_SUBDIR in ${SRC_DIRS}; do
         #
         # We also skip any dir named "cpu_codegen" in case there are
         # nGraph-generated files lying around from a test run.
-        find "${ROOT_SUBDIR}"                                      \
+        find "${ROOT_SUBDIR}"                                       \
           -name cpu_codegen -prune -o                               \
           \( -type f -and \( -name '*.cc' -or -name '*.h'           \
                              -or -name '*.cpp' -or -name '*.hpp' \) \
-             -print \) | xargs echo "${CLANG_FORMAT_PROG}" -i -style=file
+             -print \) | xargs "${CLANG_FORMAT_PROG}" -i -style=file
 
         bash_lib_status "Done."
     fi

--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+set -u
+
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+declare SRC_DIRS="src examples test logging tools"
+
+# NOTE: The results of `clang-format` depend _both_ of the following factors:
+# - The `.clang-format` file, and
+# - The particular version of the `clang-format` program being used.
+#
+# For this reason, this script specifies the exact version of clang-format to be used.
+
+declare CLANG_FORMAT_BASENAME="clang-format-3.9"
+declare REQUIRED_CLANG_FORMAT_VERSION=3.9
+
+declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "${THIS_SCRIPT_DIR}/bash_lib.sh"
+source "${THIS_SCRIPT_DIR}/clang_format_lib.sh"
+
+declare CLANG_FORMAT_PROG
+if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
+    bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
+fi
+
+clang_format_lib_verify_version "${CLANG_FORMAT_PROG}" "${REQUIRED_CLANG_FORMAT_VERSION}"
+bash_lib_status "Verified that '${CLANG_FORMAT_PROG}' has version '${REQUIRED_CLANG_FORMAT_VERSION}'"
+
+pushd "${THIS_SCRIPT_DIR}/.."
+
+declare PYBIND_WRAPPER="python/pyngraph"
+
+declare ROOT_SUBDIR
+for ROOT_SUBDIR in ${SRC_DIRS}; do
+    if ! [[ -d "${ROOT_SUBDIR}" ]]; then
+	    bash_lib_status "In directory '$(pwd)', no subdirectory named '${ROOT_SUBDIR}' was found."
+    else
+        bash_lib_status "About to format C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
+
+        # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
+        # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
+        # mechanism, and this confuses clang-format.
+        #
+        # We also skip any dir named "cpu_codegen" in case there are
+        # nGraph-generated files lying around from a test run.
+        find "${ROOT_SUBDIR}"                                      \
+          -name cpu_codegen -prune -o                               \
+          \( -type f -and \( -name '*.cc' -or -name '*.h'           \
+                             -or -name '*.cpp' -or -name '*.hpp' \) \
+             -print \) | xargs echo "${CLANG_FORMAT_PROG}" -i -style=file
+
+        bash_lib_status "Done."
+    fi
+done
+
+popd

--- a/maint/bash_lib.sh
+++ b/maint/bash_lib.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+#===================================================================================================
+# A library of general-purpose Bash functions
+#===================================================================================================
+
+declare _intelnervana_bash_lib_SCRIPT_NAME="${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}"
+declare _maint_SCRIPT_DIR="$( cd $(dirname "${_intelnervana_bash_lib_SCRIPT_NAME}") && pwd )"
+declare _intelnervana_bash_lib_IS_LOADED=1
+
+bash_lib_get_my_BASH_LINENO() {
+    echo "${BASH_LINENO[${#BASH_LINENO[@]} -1 ]}"
+}
+
+bash_lib_get_callers_BASH_LINENO() {
+    echo "${BASH_LINENO[${#BASH_LINENO[@]} - 2]}"
+}
+
+bash_lib_get_my_BASH_SOURCE() {
+    echo "${BASH_SOURCE[${#BASH_SOURCE[@]} ]}"
+}
+
+bash_lib_get_callers_BASH_SOURCE() {
+    echo "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}"
+}
+
+bash_lib_status() {
+    local CONTEXT_STRING="$(basename $(bash_lib_get_callers_BASH_SOURCE))"
+    local TEXT_LINE
+    local IS_FIRST_LINE=1
+
+    for TEXT_LINE in "${@}"; do
+        if (( IS_FIRST_LINE == 1 )); then
+            IS_FIRST_LINE=0
+            printf "%s STATUS: " "${CONTEXT_STRING}" >&2
+        else
+            printf "    " >&2
+        fi
+
+        printf "%s\n" "${TEXT_LINE}" >&2
+    done
+}
+
+bash_lib_print_error() {
+    local CONTEXT_STRING="$(basename $(bash_lib_get_callers_BASH_SOURCE)):$(bash_lib_get_callers_BASH_LINENO)"
+    local TEXT_LINE
+    local IS_FIRST_LINE=1
+
+    for TEXT_LINE in "${@}"; do
+        if (( IS_FIRST_LINE == 1 )); then
+            IS_FIRST_LINE=0
+            printf "%s ERROR: " "${CONTEXT_STRING}" >&2
+        else
+            printf "    " >&2
+        fi
+
+        printf "%s\n" "${TEXT_LINE}" >&2
+    done
+}
+
+bash_lib_die() {
+    bash_lib_print_error $@
+    exit 1
+}
+
+bash_lib_am_sudo_or_root() {
+    [ "$EUID" -eq 0 ]
+}
+
+if bash_lib_am_sudo_or_root; then
+    bash_lib_MAYBE_SUDO=''
+else
+    bash_lib_MAYBE_SUDO='sudo --set-home'
+fi
+

--- a/maint/check-code-format.sh
+++ b/maint/check-code-format.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+set -u
+
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+declare SRC_DIRS="src examples test logging tools"
+
+# NOTE: The results of `clang-format` depend _both_ of the following factors:
+# - The `.clang-format` file, and
+# - The particular version of the `clang-format` program being used.
+#
+# For this reason, this script specifies the exact version of clang-format to be used.
+
+declare CLANG_FORMAT_BASENAME="clang-format-3.9"
+declare REQUIRED_CLANG_FORMAT_VERSION=3.9
+
+declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "${THIS_SCRIPT_DIR}/bash_lib.sh"
+source "${THIS_SCRIPT_DIR}/clang_format_lib.sh"
+
+declare CLANG_FORMAT_PROG
+if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
+    bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
+fi
+
+clang_format_lib_verify_version "${CLANG_FORMAT_PROG}" "${REQUIRED_CLANG_FORMAT_VERSION}"
+bash_lib_status "Verified that '${CLANG_FORMAT_PROG}' has version '${REQUIRED_CLANG_FORMAT_VERSION}'"
+
+declare -a FAILED_FILES=()
+declare NUM_FILES_CHECKED=0
+
+pushd "${THIS_SCRIPT_DIR}/.."
+
+declare ROOT_SUBDIR
+for ROOT_SUBDIR in ${SRC_DIRS}; do
+    if ! [[ -d "${ROOT_SUBDIR}" ]]; then
+        bash_lib_status "In directory '$(pwd)', no subdirectory named '${ROOT_SUBDIR}' was found."
+    else
+        bash_lib_status "About to format C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
+        declare SRC_FILE
+        # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
+        # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
+        # mechanism, and this confuses clang-format.
+        #
+        # We also skip any dir named "cpu_codegen" in case there are
+        # nGraph-generated files lying around from a test run.
+        for SRC_FILE in $(find "${ROOT_SUBDIR}"                                      \
+                           -name cpu_codegen -prune -o                               \
+                           \( -type f -and \( -name '*.cc' -or -name '*.h'           \
+                                              -or -name '*.cpp' -or -name '*.hpp' \) \
+                              -print \) ); do
+            if "${CLANG_FORMAT_PROG}" -style=file -output-replacements-xml "${SRC_FILE}" | grep -c "<replacement " >/dev/null; then
+                FAILED_FILES+=( "${SRC_FILE}" )
+            fi
+            NUM_FILES_CHECKED=$((NUM_FILES_CHECKED+1))
+        done
+    fi
+done
+
+popd
+
+if [[ ${#FAILED_FILES[@]} -eq 0 ]]; then
+    bash_lib_status "All ${NUM_FILES_CHECKED}  C/C++ files pass the code-format check."
+else
+    echo "${#FAILED_FILES[@]} of ${NUM_FILES_CHECKED} source files failed the code-format check:"
+    declare FAILED_SRC_FILE
+    for FAILED_SRC_FILE in ${FAILED_FILES[@]}; do
+        echo "    ${FAILED_SRC_FILE}"
+    done
+    exit 1
+fi

--- a/maint/clang_format_lib.sh
+++ b/maint/clang_format_lib.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# ******************************************************************************
+# Copyright 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+#===================================================================================================
+# Provides Bash functions for dealing with clang-format.
+#===================================================================================================
+
+declare _intelnervana_clang_format_lib_SCRIPT_NAME="${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}"
+declare _maint_SCRIPT_DIR="$( cd $(dirname "${_intelnervana_clang_format_lib_SCRIPT_NAME}") && pwd )"
+
+source "${_maint_SCRIPT_DIR}/bash_lib.sh"
+
+clang_format_lib_verify_version() {
+    if (( $# != 2 )); then
+        bash_lib_print_error "Usage: ${FUNCNAME[0]} <clang-format-prog-pathname> <required-version-number>"
+        return 1
+    fi
+
+    local PROGNAME="${1}"
+    local REQUIRED_VERSION_X_Y="${2}"
+
+    if ! [[ "${REQUIRED_VERSION_X_Y}" =~ ^[0-9]+.[0-9]+$ ]]; then
+        bash_lib_print_error "${FUNCNAME[0]}: required-version-number must have the form (number).(number)."
+        return 1
+    fi
+
+    if ! [[ -f "${PROGNAME}" ]]; then
+        bash_lib_print_error "Unable to find clang-format program named '${PROGNAME}'"
+        return 1
+    fi
+
+    local VERSION_LINE
+    if ! VERSION_LINE=$("${PROGNAME}" --version); then
+        bash_lib_print_error "Failed invocation of command '${PROGNAME} --version'"
+        return 1
+    fi
+
+    local SED_FLAGS
+    if [[ "$(uname)" == 'Darwin' ]]; then
+        SED_FLAGS='-En'
+    else
+        SED_FLAGS='-rn'
+    fi
+
+    local VERSION_X_Y
+    if ! VERSION_X_Y=$(echo "${VERSION_LINE}" | sed ${SED_FLAGS} 's/^clang-format version ([0-9]+.[0-9]+).*$/\1/p')
+    then
+        bash_lib_print_error "Failed invocation of sed."
+        return 1
+    fi
+
+    if [[ "${REQUIRED_VERSION_X_Y}" != "${VERSION_X_Y}" ]]; then
+        bash_lib_print_error \
+            "Program '${PROGNAME}' reports version number '${VERSION_X_Y}'" \
+            "but we require '${REQUIRED_VERSION_X_Y}'"
+        return 1
+    fi
+}
+

--- a/test/ci/docker/Dockerfile.ngraph-tf-ci
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci
@@ -37,7 +37,8 @@ RUN apt-get update &&  apt-get install -y \
     build-essential cmake \
     libtinfo-dev \
     zip golang-go \
-    locate curl
+    locate curl \
+    clang-format-3.9
 
 # The "locate" command uses a prepopulated index.  If this index is not built,
 # then "locate" will find absolutely nothing.  In Tensorflow's configure,

--- a/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
@@ -129,6 +129,14 @@ if [ ! -d "${trained_resnet50_model}" ] ; then
     exit 1
 fi
 
+xtime="$(date)"
+echo  ' '
+echo  "===== Starting nGraph TensorFlow Bridge Source Code Format Check at ${xtime} ====="
+echo  ' '
+
+cd "${bridge_dir}"
+maint/check-code-format.sh
+
 # Make sure the Bazel cache is in /tmp, as docker images have too little space
 # in the root filesystem, where /home (and $HOME/.cache) is.  Even though we
 # may not be using the Bazel cache in the builds (in docker), we do this anyway


### PR DESCRIPTION
Porting this stuff over from the main `ngraph` repo. Had to make a few minor changes to the scripts there as follows:

* Different source dir names
* Have to take in `.cc` and `.h` as well
* Exclude `cpu_codegen` from search paths

I think we should merge to `master` rather than `r0.4` to minimize disruption for now. Note that the format check will actually _fail_ on CI for now. I don't want to actually run the format script until `r0.4` and `master` are back together.