### PR TITLE
Add keras_applications package to Dockerfile for automated builds

### DIFF
--- a/test/ci/docker/Dockerfile.ngraph-tf-ci
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci
@@ -47,9 +47,11 @@ RUN updatedb
 
 # six, enum34 and mock are required for building the tensorflow wheel
 # scipy, portpicker, and sklearn are needed by some TensorFlow tests
+# keras_applications is needed for modern TensorFlow builds
 RUN pip install --upgrade pip
 RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
+RUN pip install keras_applications
 
 # We include pytest so the Docker image can be used for daily validation
 RUN pip install --upgrade pytest


### PR DESCRIPTION
Daily builds of NervanaSystems/tensorflow started failing with an error that said the keras_applicatons python package was not found. This quick PR adds a "pip install keras_applications" to the Dockerfile for the automated builds, which allows the tensorflow build to pass.

This PR has been tested with both ngraph-tf and NervanaSystems/tensorflow automated builds (run manually from the command-line). Both pass.

Successful testing: https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/175/