### PR TITLE
Igor/fusedbatchnorm fix

### DIFF
--- a/src/ngraph_conversions.h
+++ b/src/ngraph_conversions.h
@@ -27,10 +27,11 @@ void Reshape(std::shared_ptr<ng::Node>& ng_node) {
   static_assert(a != b && a != c && a != d && b != c && b != d && c != d,
                 "Dimensions indices cannot be equal");
   auto& s = ng_node->get_shape();
-  ng::Shape reshaped_shape{s[a], s[b], s[c], s[d]};
-  NGRAPH_VLOG(3) << "reshaped_shape: " << ng::join(reshaped_shape);
-  ng_node = std::make_shared<ng::op::Reshape>(
-      ng_node, ng::AxisVector{a, b, c, d}, reshaped_shape);
+  ngraph::Shape reshaped_shape{s[a], s[b], s[c], s[d]};
+  NGRAPH_VLOG(3) << "reshaping " << ngraph::join(s) << " to "
+                 << ngraph::join(reshaped_shape);
+  ng_node = std::make_shared<ngraph::op::Reshape>(
+      ng_node, ngraph::AxisVector{a, b, c, d}, reshaped_shape);
 }
 
 namespace detail {

--- a/test/python/test_fusedbatchnorm.py
+++ b/test/python/test_fusedbatchnorm.py
@@ -1,0 +1,55 @@
+# ==============================================================================
+#  Copyright 2018 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ==============================================================================
+"""nGraph TensorFlow FusedBatchNorm test
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from common import NgraphTest
+
+
+class TestFusedBatchNorm(NgraphTest):
+  def test_fusedbatchnorm(self):
+    x = np.random.rand(64, 3, 10, 8).astype('f')
+    scale = [1.0, 0.9, 1.1]
+    offset = [0.1, 0.2, -.3]
+
+    with self.device:
+      norm = tf.nn.fused_batch_norm(x, scale, offset, data_format='NCHW')
+
+      with self.session as sess:
+        import pdb
+        pdb.set_trace()
+        result = sess.run(norm)
+
+    with tf.device('/cpu:0'):
+      x_t = tf.transpose(x, (0, 2, 3, 1))
+      # tensorflow CPU doesn't support NCHW
+      norm = tf.nn.fused_batch_norm(x_t, scale, offset, data_format='NHWC')
+
+      with self.session as sess:
+        expected = sess.run(norm)
+
+    np.testing.assert_allclose(result[0],
+                               np.transpose(expected[0], (0, 3, 1, 2)),
+                               rtol=0.01)
+    np.testing.assert_allclose(result[1], expected[1], rtol=0.01)
+    np.testing.assert_allclose(result[2], expected[2], rtol=0.01)

--- a/test/python/test_fusedbatchnorm.py
+++ b/test/python/test_fusedbatchnorm.py
@@ -27,23 +27,23 @@ from common import NgraphTest
 
 
 class TestFusedBatchNorm(NgraphTest):
-  def test_fusedbatchnorm(self):
-    x = np.random.rand(64, 3, 10, 8).astype('f')
-    scale = [1.0, 0.9, 1.1]
-    offset = [0.1, 0.2, -.3]
+  x = np.random.rand(64, 3, 10, 8).astype('f')
+  scale = [1.0, 0.9, 1.1]
+  offset = [0.1, 0.2, -.3]
 
+  def test_fusedbatchnorm_nchw(self):
     with self.device:
-      norm = tf.nn.fused_batch_norm(x, scale, offset, data_format='NCHW')
+      norm = tf.nn.fused_batch_norm(self.x, self.scale, self.offset,
+                                    data_format='NCHW')
 
       with self.session as sess:
-        import pdb
-        pdb.set_trace()
         result = sess.run(norm)
 
     with tf.device('/cpu:0'):
-      x_t = tf.transpose(x, (0, 2, 3, 1))
+      x_t = tf.transpose(self.x, (0, 2, 3, 1))
       # tensorflow CPU doesn't support NCHW
-      norm = tf.nn.fused_batch_norm(x_t, scale, offset, data_format='NHWC')
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset,
+                                    data_format='NHWC')
 
       with self.session as sess:
         expected = sess.run(norm)
@@ -51,5 +51,26 @@ class TestFusedBatchNorm(NgraphTest):
     np.testing.assert_allclose(result[0],
                                np.transpose(expected[0], (0, 3, 1, 2)),
                                rtol=0.01)
+    np.testing.assert_allclose(result[1], expected[1], rtol=0.01)
+    np.testing.assert_allclose(result[2], expected[2], rtol=0.01)
+
+  def test_fusedbatchnorm_nhwc(self):
+    x_t = tf.transpose(self.x, (0, 2, 3, 1))
+
+    with self.device:
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset,
+                                    data_format='NHWC')
+
+      with self.session as sess:
+        result = sess.run(norm)
+
+    with tf.device('/cpu:0'):
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset,
+                                    data_format='NHWC')
+
+      with self.session as sess:
+        expected = sess.run(norm)
+
+    np.testing.assert_allclose(result[0], expected[0], rtol=0.01)
     np.testing.assert_allclose(result[1], expected[1], rtol=0.01)
     np.testing.assert_allclose(result[2], expected[2], rtol=0.01)

--- a/test/python/test_fusedbatchnorm.py
+++ b/test/python/test_fusedbatchnorm.py
@@ -26,10 +26,16 @@ import tensorflow as tf
 from common import NgraphTest
 
 
+# yes, it works without (tested over 1000 runs) but there's always a chance
+np.random.seed(5)
+
+
 class TestFusedBatchNorm(NgraphTest):
   x = np.random.rand(64, 3, 10, 8).astype('f')
   scale = [1.0, 0.9, 1.1]
   offset = [0.1, 0.2, -.3]
+  mean = [0.4, 0.5, 0.6]
+  variance = [0.1, 0.2, 0.3]
 
   def test_fusedbatchnorm_nchw(self):
     with self.device:
@@ -50,9 +56,9 @@ class TestFusedBatchNorm(NgraphTest):
 
     np.testing.assert_allclose(result[0],
                                np.transpose(expected[0], (0, 3, 1, 2)),
-                               rtol=0.01)
-    np.testing.assert_allclose(result[1], expected[1], rtol=0.01)
-    np.testing.assert_allclose(result[2], expected[2], rtol=0.01)
+                               rtol=0, atol=5e-5)
+    np.testing.assert_allclose(result[1], expected[1], rtol=0, atol=5e-5)
+    np.testing.assert_allclose(result[2], expected[2], rtol=0, atol=5e-5)
 
   def test_fusedbatchnorm_nhwc(self):
     x_t = tf.transpose(self.x, (0, 2, 3, 1))
@@ -71,6 +77,48 @@ class TestFusedBatchNorm(NgraphTest):
       with self.session as sess:
         expected = sess.run(norm)
 
-    np.testing.assert_allclose(result[0], expected[0], rtol=0.01)
-    np.testing.assert_allclose(result[1], expected[1], rtol=0.01)
-    np.testing.assert_allclose(result[2], expected[2], rtol=0.01)
+    np.testing.assert_allclose(result[0], expected[0], rtol=0, atol=5e-5)
+    np.testing.assert_allclose(result[1], expected[1], rtol=0, atol=5e-5)
+    np.testing.assert_allclose(result[2], expected[2], rtol=0, atol=5e-5)
+
+  def test_fusedbatchnorm_inference_nchw(self):
+    with self.device:
+      norm = tf.nn.fused_batch_norm(self.x, self.scale, self.offset, self.mean,
+                                    self.variance, data_format='NCHW',
+                                    is_training=False)
+
+      with self.session as sess:
+        result = sess.run(norm[0])
+
+    with tf.device('/cpu:0'):
+      x_t = tf.transpose(self.x, (0, 2, 3, 1))
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset, self.mean,
+                                    self.variance, data_format='NHWC',
+                                    is_training=False)
+
+      with self.session as sess:
+        expected = sess.run(norm[0])
+
+    np.testing.assert_allclose(result, np.transpose(expected, (0, 3, 1, 2)),
+                               rtol=0, atol=5e-5)
+
+  def test_fusedbatchnorm_inference_nhwc(self):
+    x_t = tf.transpose(self.x, (0, 2, 3, 1))
+
+    with self.device:
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset, self.mean,
+                                    self.variance, data_format='NHWC',
+                                    is_training=False)
+
+      with self.session as sess:
+        result = sess.run(norm[0])
+
+    with tf.device('/cpu:0'):
+      norm = tf.nn.fused_batch_norm(x_t, self.scale, self.offset, self.mean,
+                                    self.variance, data_format='NHWC',
+                                    is_training=False)
+
+      with self.session as sess:
+        expected = sess.run(norm[0])
+
+    np.testing.assert_allclose(result, expected, rtol=0, atol=5e-5)


### PR DESCRIPTION
Fixed FusedBatchNorm to actually work.  It also now has a test.  Furthermore, tweaked `GetInputNode` to provide more detail on errors.

The test fails sometimes when rtol < 0.01, which doesn't seem right to me.  Also, I updated the epsilon to TensorFlow's default, let me know if that's the wrong thing to do.