### PR TITLE
Better logging of cluster assignments

### DIFF
--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -216,9 +216,11 @@ Status AssignClusters(Graph* graph) {
       int cluster_idx = NGraphClusterManager::NewCluster();
 
       for (auto node : cluster->nodes) {
-        NGRAPH_VLOG(2) << ">> cluster " << cluster_idx << ": " << node
-                       << " :: " << node->name() << " [" << node->type_string()
-                       << "]";
+        if (NGRAPH_VLOG_IS_ON(5)) {
+          NGRAPH_VLOG(5) << ">> cluster " << cluster_idx << ": " << node
+                         << " :: " << node->name() << " ["
+                         << node->type_string() << "]";
+        }
 
         if (!NodeIsMarkedForClustering(node)) {
           return errors::Internal("Node ", node->DebugString(),
@@ -229,6 +231,8 @@ Status AssignClusters(Graph* graph) {
         // TODO(amprocte): move attr name to a constant
         node->AddAttr("_ngraph_cluster", cluster_idx);
       }
+
+      seen.insert(cluster);
     }
   }
   NGRAPH_VLOG(2) << "Tagging done";

--- a/src/ngraph_deassign_clusters.cc
+++ b/src/ngraph_deassign_clusters.cc
@@ -99,6 +99,47 @@ Status DeassignClusters(Graph* graph) {
     }
   }
 
+  //
+  // At this point we have made our final decision about cluster assignment, so
+  // we will log the cluster assignment now.
+  //
+  if (NGRAPH_VLOG_IS_ON(2)) {
+    // Can't quite reuse cluster_map here, unfortunately.
+    std::map<int, std::set<const Node*>> final_cluster_map;
+
+    for (auto node : graph->nodes()) {
+      int cluster_idx;
+      if (!GetNodeCluster(node, &cluster_idx).ok()) {
+        cluster_idx = -1;
+      }
+      final_cluster_map[cluster_idx].insert(node);
+    }
+
+    for (auto kv : final_cluster_map) {
+      int cluster_idx = kv.first;
+      std::set<const Node*>& nodes = kv.second;
+
+      if (cluster_idx == -1) {
+        NGRAPH_VLOG(2) << "FINAL CLUSTER ASSIGNMENT: NO CLUSTER ("
+                       << nodes.size() << " NODES)";
+        NGRAPH_VLOG(2) << "===================================================="
+                          "===============";
+      } else {
+        NGRAPH_VLOG(2) << "FINAL CLUSTER ASSIGNMENT: CLUSTER " << cluster_idx
+                       << " (" << nodes.size() << " NODES)";
+        NGRAPH_VLOG(2) << "===================================================="
+                          "===============";
+      }
+
+      for (auto node : nodes) {
+        NGRAPH_VLOG(2) << node->name() << "[" << node->type_string() << "]";
+        NGRAPH_VLOG(3) << node->DebugString();
+      }
+
+      NGRAPH_VLOG(2) << "";
+    }
+  }
+
   return Status::OK();
 }
 

--- a/src/ngraph_deassign_clusters.cc
+++ b/src/ngraph_deassign_clusters.cc
@@ -120,23 +120,27 @@ Status DeassignClusters(Graph* graph) {
       std::set<const Node*>& nodes = kv.second;
 
       if (cluster_idx == -1) {
-        NGRAPH_VLOG(2) << "FINAL CLUSTER ASSIGNMENT: NO CLUSTER ("
-                       << nodes.size() << " NODES)";
-        NGRAPH_VLOG(2) << "===================================================="
+        NGRAPH_VLOG(2)
+            << "NGRAPH_CLUSTERS: FINAL CLUSTER ASSIGNMENT: NO CLUSTER ("
+            << nodes.size() << " NODES)";
+        NGRAPH_VLOG(2) << "NGRAPH_CLUSTERS: "
+                          "===================================================="
                           "===============";
       } else {
-        NGRAPH_VLOG(2) << "FINAL CLUSTER ASSIGNMENT: CLUSTER " << cluster_idx
-                       << " (" << nodes.size() << " NODES)";
-        NGRAPH_VLOG(2) << "===================================================="
+        NGRAPH_VLOG(2) << "NGRAPH_CLUSTERS: FINAL CLUSTER ASSIGNMENT: CLUSTER "
+                       << cluster_idx << " (" << nodes.size() << " NODES)";
+        NGRAPH_VLOG(2) << "NGRAPH_CLUSTERS: "
+                          "===================================================="
                           "===============";
       }
 
       for (auto node : nodes) {
-        NGRAPH_VLOG(2) << node->name() << "[" << node->type_string() << "]";
-        NGRAPH_VLOG(3) << node->DebugString();
+        NGRAPH_VLOG(2) << "NGRAPH_CLUSTERS: " << node->name() << " ["
+                       << node->type_string() << "]";
+        NGRAPH_VLOG(3) << "NGRAPH_CLUSTERS: " << node->DebugString();
       }
 
-      NGRAPH_VLOG(2) << "";
+      NGRAPH_VLOG(2) << "NGRAPH_CLUSTERS: ";
     }
   }
 


### PR DESCRIPTION
This gives an easier-to-digest log format for cluster assignments, visible when `NGRAPH_VLOG_LEVEL=2`. For example:

```
2018-08-20 14:06:58.295602: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:128] FINAL CLUSTER ASSIGNMENT: CLUSTER 0 (7 NODES)
2018-08-20 14:06:58.295609: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:130] ===================================================================
2018-08-20 14:06:58.295614: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv24/conv2d/kernel/Initializer/random_uniform/min[Const]
2018-08-20 14:06:58.295620: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v113/conv44/conv2d/kernel/Initializer/random_uniform/sub[Const]
2018-08-20 14:06:58.295626: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v113/conv44/conv2d/kernel/Initializer/random_uniform/mul[Mul]
2018-08-20 14:06:58.295632: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv24/conv2d/kernel/Initializer/random_uniform[Add]
2018-08-20 14:06:58.295638: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv24/conv2d/kernel/Initializer/random_uniform/mul[Mul]
2018-08-20 14:06:58.295644: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v113/conv44/conv2d/kernel/Initializer/random_uniform[Add]
2018-08-20 14:06:58.295650: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v113/conv44/conv2d/kernel/Initializer/random_uniform/min[Const]
2018-08-20 14:06:58.295656: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:139] 
2018-08-20 14:06:58.295663: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:128] FINAL CLUSTER ASSIGNMENT: CLUSTER 6 (7 NODES)
2018-08-20 14:06:58.295669: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:130] ===================================================================
2018-08-20 14:06:58.295674: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v13/conv11/conv2d/kernel/Initializer/random_uniform/sub[Const]
2018-08-20 14:06:58.295680: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv25/conv2d/kernel/Initializer/random_uniform/min[Const]
2018-08-20 14:06:58.295686: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v13/conv11/conv2d/kernel/Initializer/random_uniform/mul[Mul]
2018-08-20 14:06:58.295692: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v13/conv11/conv2d/kernel/Initializer/random_uniform[Add]
2018-08-20 14:06:58.295698: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv25/conv2d/kernel/Initializer/random_uniform[Add]
2018-08-20 14:06:58.295704: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v17/conv25/conv2d/kernel/Initializer/random_uniform/mul[Mul]
2018-08-20 14:06:58.295710: I /localdisk/amprocte/tf-di/ngraph-tf/src/ngraph_deassign_clusters.cc:135] v0/cg/resnet_v13/conv11/conv2d/kernel/Initializer/random_uniform/min[Const]
...
```

Also throws in a fix for a minor bug in assign_clusters where we were doing a bunch of unnecessary reassignment of the _ngraph_cluster attribute.