### PR TITLE
Fix default run-type for docker container command line runs

### DIFF
--- a/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
@@ -66,7 +66,7 @@ fi
 # Set defaults
 
 if [ -z "${NG_TF_RUN_TYPE}" ] ; then
-    NG_TF_RUN_TYPE='ngraph'  # Default is to run with ngraph
+    NG_TF_RUN_TYPE='ngraph-tf'  # Default is to run with ngraph
 fi
 
 if [ -z "${NG_TF_PY_VERSION}" ] ; then


### PR DESCRIPTION
Fix for the default run-type for running commands (inference models) in a docker container.
