### PR TITLE
Shrestha/fix bug strided slice shrink mask

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1300,9 +1300,8 @@ static Status TranslateFillOp(
     ng_output_shape[i] = dims_vec[i];
     ng_axis_set.insert(i);
   }
-  SaveNgOp(
-      ng_op_map, op->name(),
-      make_shared<ng::op::Broadcast>(ng_value, ng_output_shape, ng_axis_set));
+  SaveNgOp(ng_op_map, op->name(), make_shared<ng::op::Broadcast>(
+                                      ng_value, ng_output_shape, ng_axis_set));
   return Status::OK();
 }
 
@@ -2425,32 +2424,42 @@ static Status TranslateStridedSliceOp(
 
   std::shared_ptr<ng::Node> ng_strided_slice =
       make_shared<ng::op::Slice>(ng_input, l, u, s);
-  
-  
-  // Get shrink axis
-  vector<int> shrink_axis;
-  int shrink_axis_mask = tf_shrink_axis_mask;
 
-  int axis=0;
-  while(shrink_axis_mask!=0){
-    if((shrink_axis_mask & 1) ==1){
-      shrink_axis.push_back(axis);
-    }
-    axis++;
-    shrink_axis_mask>>=1;
-  }
-
-  NGRAPH_VLOG(3) << " Shrink axis "<< ng::join(shrink_axis);
+  NGRAPH_VLOG(3) << " NG Lower Vector " << ng::join(lower_vec);
+  NGRAPH_VLOG(3) << " NG End Vector " << ng::join(end_vec);
+  NGRAPH_VLOG(3) << " NG Stride Vector " << ng::join(stride_vec);
 
   if (tf_shrink_axis_mask) {
+    set<int> shrink_axis;
+    int64 shrink_axis_mask = tf_shrink_axis_mask;
+
+    for (int i = 0; i < 64; i++) {
+      if ((shrink_axis_mask & 1) == 1) {
+        shrink_axis.insert(i);
+      }
+      shrink_axis_mask >>= 1;
+    }
+
+    NGRAPH_VLOG(3) << "Shrink axis mask " << tf_shrink_axis_mask;
+    NGRAPH_VLOG(3) << " Shrink axis " << ng::join(shrink_axis);
+
+    vector<size_t> output_shape;
+    for (int i = 0; i < lower_vec.size(); i++) {
+      if (shrink_axis.find(i) == shrink_axis.end()) {
+        output_shape.push_back(end_vec[i] - lower_vec[i]);
+      }
+    }
+
+    ng::Shape ng_final_shape(output_shape);
     ng::AxisVector ng_axis_order(input_shape.size());
     for (size_t i = 0; i < input_shape.size(); i++) {
       ng_axis_order[i] = i;
     }
+    NGRAPH_VLOG(3) << " Output  shape " << ng::join(output_shape);
+    NGRAPH_VLOG(3) << " NG  axis order " << ng::join(ng_axis_order);
 
-    ng::Shape ng_shape(input_shape.begin() + 1, input_shape.end());
-    ng_strided_slice =
-        make_shared<ng::op::Reshape>(ng_strided_slice, ng_axis_order, ng_shape);
+    ng_strided_slice = make_shared<ng::op::Reshape>(
+        ng_strided_slice, ng_axis_order, ng_final_shape);
   }
 
   SaveNgOp(ng_op_map, op->name(), ng_strided_slice);

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1313,9 +1313,8 @@ static Status TranslateFillOp(
     ng_output_shape[i] = dims_vec[i];
     ng_axis_set.insert(i);
   }
-  SaveNgOp(
-      ng_op_map, op->name(),
-      make_shared<ng::op::Broadcast>(ng_value, ng_output_shape, ng_axis_set));
+  SaveNgOp(ng_op_map, op->name(), make_shared<ng::op::Broadcast>(
+                                      ng_value, ng_output_shape, ng_axis_set));
   return Status::OK();
 }
 
@@ -2845,8 +2844,8 @@ Status Builder::TranslateGraph(
     } catch (const std::exception& e) {
       return errors::Internal("Unhandled exception in op handler: ", op->name(),
                               " (", op->type_string(), ")\n",
-                              op->def().DebugString(), "\n",
-                              "what(): ", e.what());
+                              op->def().DebugString(), "\n", "what(): ",
+                              e.what());
     }
   }
 

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1300,8 +1300,9 @@ static Status TranslateFillOp(
     ng_output_shape[i] = dims_vec[i];
     ng_axis_set.insert(i);
   }
-  SaveNgOp(ng_op_map, op->name(), make_shared<ng::op::Broadcast>(
-                                      ng_value, ng_output_shape, ng_axis_set));
+  SaveNgOp(
+      ng_op_map, op->name(),
+      make_shared<ng::op::Broadcast>(ng_value, ng_output_shape, ng_axis_set));
   return Status::OK();
 }
 
@@ -2424,6 +2425,23 @@ static Status TranslateStridedSliceOp(
 
   std::shared_ptr<ng::Node> ng_strided_slice =
       make_shared<ng::op::Slice>(ng_input, l, u, s);
+  
+  
+  // Get shrink axis
+  vector<int> shrink_axis;
+  int shrink_axis_mask = tf_shrink_axis_mask;
+
+  int axis=0;
+  while(shrink_axis_mask!=0){
+    if((shrink_axis_mask & 1) ==1){
+      shrink_axis.push_back(axis);
+    }
+    axis++;
+    shrink_axis_mask>>=1;
+  }
+
+  NGRAPH_VLOG(3) << " Shrink axis "<< ng::join(shrink_axis);
+
   if (tf_shrink_axis_mask) {
     ng::AxisVector ng_axis_order(input_shape.size());
     for (size_t i = 0; i < input_shape.size(); i++) {

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -2442,26 +2442,19 @@ static Status TranslateStridedSliceOp(
   NGRAPH_VLOG(3) << " NG End Vector " << ng::join(end_vec);
   NGRAPH_VLOG(3) << " NG Stride Vector " << ng::join(stride_vec);
 
+  vector<size_t> output_shape;
   if (tf_shrink_axis_mask) {
-    set<int> shrink_axis;
     int64 shrink_axis_mask = tf_shrink_axis_mask;
+    vector<size_t> output_shape;
 
-    for (int i = 0; i < 64; i++) {
-      if ((shrink_axis_mask & 1) == 1) {
-        shrink_axis.insert(i);
+    for (int i = 0; i < lower_vec.size(); i++) {
+      if ((shrink_axis_mask & 1) != 1) {
+        output_shape.push_back(end_vec[i] - lower_vec[i]);
       }
       shrink_axis_mask >>= 1;
     }
 
     NGRAPH_VLOG(3) << "Shrink axis mask " << tf_shrink_axis_mask;
-    NGRAPH_VLOG(3) << " Shrink axis " << ng::join(shrink_axis);
-
-    vector<size_t> output_shape;
-    for (int i = 0; i < lower_vec.size(); i++) {
-      if (shrink_axis.find(i) == shrink_axis.end()) {
-        output_shape.push_back(end_vec[i] - lower_vec[i]);
-      }
-    }
 
     ng::Shape ng_final_shape(output_shape);
     ng::AxisVector ng_axis_order(input_shape.size());

--- a/test/python/test_slice.py
+++ b/test/python/test_slice.py
@@ -78,6 +78,9 @@ class TestSliceOperations(NgraphTest):
     slice_ts.append(x[0][1])
     slice_ts.append(x[-1])
 
+    # unsupported currently
+    # slice_ts.append(x[:, tf.newaxis])
+
     def run_test(sess):
       return sess.run(slice_ts, feed_dict={x: a})
 

--- a/test/python/test_slice.py
+++ b/test/python/test_slice.py
@@ -36,25 +36,25 @@ class TestSliceOperations(NgraphTest):
     inp = np.random.rand(4, 4).astype("f")
     slice_ts = []
     expected = []
-    
+
     a = np.array([float(x) for x in inp.ravel(order="C")])
     a.shape = (4, 4)
-    
+
     x = tf.placeholder(dtype=dtypes.float32)
     slice_ts.append(array_ops.slice(x, [0, 0], [2, 2]))
     slice_ts.append(array_ops.slice(x, [0, 0], [-1, -1]))
     slice_ts.append(array_ops.slice(x, [2, 2], [-1, -1]))
-    def run_test(sess):
-        return sess.run(slice_ts,feed_dict={ x: a })
-    slice_vals = self.with_ngraph(run_test)
 
+    def run_test(sess):
+      return sess.run(slice_ts, feed_dict={x: a})
+    slice_vals = self.with_ngraph(run_test)
 
     expected.append(inp[:2, :2])
     expected.append(inp[:, :])
     expected.append(inp[2:, 2:])
 
     for v, e in zip(slice_vals, expected):
-        np.testing.assert_array_equal(v, e)
+      np.testing.assert_array_equal(v, e)
 
   def test_strided_slice(self):
     inp = np.random.rand(4, 5).astype("f")
@@ -62,15 +62,15 @@ class TestSliceOperations(NgraphTest):
     expected = []
     a = np.array([float(x) for x in inp.ravel(order="C")])
     a.shape = (4, 5)
-    
+
     x = tf.placeholder(dtype=dtypes.float32)
-    
+
     slice_ts.append(x[:])
     slice_ts.append(x[...])
     slice_ts.append(x[:, :])
     slice_ts.append(x[:, ...])
     slice_ts.append(x[1:, :-2])
-    slice_ts.append(x[::2,:-2])
+    slice_ts.append(x[::2, :-2])
     slice_ts.append(x[1, :])
     slice_ts.append(x[:, 1])
     slice_ts.append(x[1, 1])
@@ -79,17 +79,16 @@ class TestSliceOperations(NgraphTest):
     slice_ts.append(x[-1])
 
     def run_test(sess):
-        return sess.run(slice_ts, feed_dict={ x: a })
-    
+      return sess.run(slice_ts, feed_dict={x: a})
+
     slice_vals = self.with_ngraph(run_test)
 
-    
     expected.append(inp[:])
     expected.append(inp[...])
     expected.append(inp[:, :])
     expected.append(inp[:, ...])
     expected.append(inp[1:, :-2])
-    expected.append(inp[::2,:-2])
+    expected.append(inp[::2, :-2])
     expected.append(inp[1, :])
     expected.append(inp[:, 1])
     expected.append(inp[1, 1])
@@ -98,4 +97,4 @@ class TestSliceOperations(NgraphTest):
     expected.append(inp[-1])
 
     for v, e in zip(slice_vals, expected):
-        np.testing.assert_array_equal(v, e)
+      np.testing.assert_array_equal(v, e)

--- a/test/python/test_slice.py
+++ b/test/python/test_slice.py
@@ -32,7 +32,6 @@ from common import NgraphTest
 
 
 class TestSliceOperations(NgraphTest):
-  '''
   def test_slice(self):
     inp = np.random.rand(4, 4).astype("f")
     slice_ts = []
@@ -56,9 +55,8 @@ class TestSliceOperations(NgraphTest):
 
     for v, e in zip(slice_vals, expected):
         np.testing.assert_array_equal(v, e)
-  '''
+
   def test_strided_slice(self):
-    print("Running strided slice")
     inp = np.random.rand(4, 5).astype("f")
     slice_ts = []
     expected = []
@@ -68,19 +66,17 @@ class TestSliceOperations(NgraphTest):
     x = tf.placeholder(dtype=dtypes.float32)
     
     slice_ts.append(x[:])
-    
     slice_ts.append(x[...])
     slice_ts.append(x[:, :])
     slice_ts.append(x[:, ...])
     slice_ts.append(x[1:, :-2])
     slice_ts.append(x[::2,:-2])
-    #slice_ts.append(x[1, :])
-    #slice_ts.append(x[:, 1])
+    slice_ts.append(x[1, :])
+    slice_ts.append(x[:, 1])
     slice_ts.append(x[1, 1])
     slice_ts.append(x[0])
     slice_ts.append(x[0][1])
     slice_ts.append(x[-1])
-    
 
     def run_test(sess):
         return sess.run(slice_ts, feed_dict={ x: a })
@@ -89,19 +85,17 @@ class TestSliceOperations(NgraphTest):
 
     
     expected.append(inp[:])
-    
     expected.append(inp[...])
     expected.append(inp[:, :])
     expected.append(inp[:, ...])
     expected.append(inp[1:, :-2])
     expected.append(inp[::2,:-2])
-    #expected.append(inp[1, :])
-    #expected.append(inp[:, 1])
+    expected.append(inp[1, :])
+    expected.append(inp[:, 1])
     expected.append(inp[1, 1])
     expected.append(inp[0])
     expected.append(inp[0][1])
     expected.append(inp[-1])
-    
 
     for v, e in zip(slice_vals, expected):
         np.testing.assert_array_equal(v, e)

--- a/test/python/test_slice.py
+++ b/test/python/test_slice.py
@@ -21,6 +21,7 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
+import tensorflow as tf
 
 import numpy as np
 from tensorflow.python.framework import constant_op
@@ -30,24 +31,24 @@ from tensorflow.python.ops import array_ops
 from common import NgraphTest
 
 
-@pytest.mark.skip(reason="new deviceless mode WIP")
 class TestSliceOperations(NgraphTest):
+  '''
   def test_slice(self):
-    with self.device:
-      inp = np.random.rand(4, 4).astype("f")
-      slice_ts = []
-      expected = []
+    inp = np.random.rand(4, 4).astype("f")
+    slice_ts = []
+    expected = []
+    
+    a = np.array([float(x) for x in inp.ravel(order="C")])
+    a.shape = (4, 4)
+    
+    x = tf.placeholder(dtype=dtypes.float32)
+    slice_ts.append(array_ops.slice(x, [0, 0], [2, 2]))
+    slice_ts.append(array_ops.slice(x, [0, 0], [-1, -1]))
+    slice_ts.append(array_ops.slice(x, [2, 2], [-1, -1]))
+    def run_test(sess):
+        return sess.run(slice_ts,feed_dict={ x: a })
+    slice_vals = self.with_ngraph(run_test)
 
-      with self.session as sess:
-        a = constant_op.constant(
-            [float(x) for x in inp.ravel(order="C")],
-            shape=[4, 4],
-            dtype=dtypes.float32)
-        slice_ts.append(array_ops.slice(a, [0, 0], [2, 2]))
-        slice_ts.append(array_ops.slice(a, [0, 0], [-1, -1]))
-        slice_ts.append(array_ops.slice(a, [2, 2], [-1, -1]))
-
-        slice_vals = sess.run(slice_ts)
 
     expected.append(inp[:2, :2])
     expected.append(inp[:, :])
@@ -55,41 +56,52 @@ class TestSliceOperations(NgraphTest):
 
     for v, e in zip(slice_vals, expected):
         np.testing.assert_array_equal(v, e)
-
+  '''
   def test_strided_slice(self):
-    with self.device:
-      inp = np.random.rand(4, 4).astype("f")
-      slice_ts = []
-      expected = []
+    print("Running strided slice")
+    inp = np.random.rand(4, 5).astype("f")
+    slice_ts = []
+    expected = []
+    a = np.array([float(x) for x in inp.ravel(order="C")])
+    a.shape = (4, 5)
+    
+    x = tf.placeholder(dtype=dtypes.float32)
+    
+    slice_ts.append(x[:])
+    
+    slice_ts.append(x[...])
+    slice_ts.append(x[:, :])
+    slice_ts.append(x[:, ...])
+    slice_ts.append(x[1:, :-2])
+    slice_ts.append(x[::2,:-2])
+    #slice_ts.append(x[1, :])
+    #slice_ts.append(x[:, 1])
+    slice_ts.append(x[1, 1])
+    slice_ts.append(x[0])
+    slice_ts.append(x[0][1])
+    slice_ts.append(x[-1])
+    
 
-      with self.session as sess:
-        a = constant_op.constant(
-            [float(x) for x in inp.ravel(order="C")],
-            shape=[4, 4],
-            dtype=dtypes.float32)
-        slice_ts.append(a[:])
-        slice_ts.append(a[...])
-        slice_ts.append(a[:, :])
-        slice_ts.append(a[:, ...])
-        slice_ts.append(a[1:, :-2])
-        slice_ts.append(a[::2, :-2])
-        slice_ts.append(a[1, :])
-        slice_ts.append(a[0])
-        slice_ts.append(a[0][1])
-        slice_ts.append(a[-1])
+    def run_test(sess):
+        return sess.run(slice_ts, feed_dict={ x: a })
+    
+    slice_vals = self.with_ngraph(run_test)
 
-        slice_vals = sess.run(slice_ts)
-
+    
     expected.append(inp[:])
+    
     expected.append(inp[...])
     expected.append(inp[:, :])
     expected.append(inp[:, ...])
     expected.append(inp[1:, :-2])
-    expected.append(inp[::2, :-2])
-    expected.append(inp[1, :])
+    expected.append(inp[::2,:-2])
+    #expected.append(inp[1, :])
+    #expected.append(inp[:, 1])
+    expected.append(inp[1, 1])
     expected.append(inp[0])
     expected.append(inp[0][1])
     expected.append(inp[-1])
+    
 
     for v, e in zip(slice_vals, expected):
         np.testing.assert_array_equal(v, e)


### PR DESCRIPTION
Treat ShrinkAxisMask as a mask and not a boolean. It's a very small fix and does not handle all cases. E.g., final shape does not account for the strided vector or the ordering. More work required for full implementation. PR to enable testing of models. 