### PR TITLE
Langjian/fused batch nor grad training only

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1489,11 +1489,13 @@ static Status TranslateFusedBatchNormGradOp(
   SaveNgOp(ng_op_map, op->name(), ng_beta_delta_op);
   // Output reserve_space_3: Unused placeholder to match the mean input 
   // in FusedBatchNorm.
-  std::shared_ptr<ng::Node> output_mean;
+  std::shared_ptr<ng::Node> output_mean = make_shared<ngraph::op::Constant>(
+      ng_mean->get_element_type(), ng::Shape{}, std::vector<std::string>{""});
   SaveNgOp(ng_op_map, op->name(), output_mean);
   // Output reserve_space_4: Unused placeholder to match the variance input 
   // in FusedBatchNorm.
-  std::shared_ptr<ng::Node> output_variance;
+  std::shared_ptr<ng::Node> output_variance = make_shared<ngraph::op::Constant>(
+      ng_variance->get_element_type(), ng::Shape{}, std::vector<std::string>{""});
   SaveNgOp(ng_op_map, op->name(), output_variance);
 
   return Status::OK();

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1487,6 +1487,14 @@ static Status TranslateFusedBatchNormGradOp(
   SaveNgOp(ng_op_map, op->name(), ng_input_delta_op);
   SaveNgOp(ng_op_map, op->name(), ng_scale_delta_op);
   SaveNgOp(ng_op_map, op->name(), ng_beta_delta_op);
+  // Output reserve_space_3: Unused placeholder to match the mean input 
+  // in FusedBatchNorm.
+  std::shared_ptr<ng::Node> output_mean;
+  SaveNgOp(ng_op_map, op->name(), output_mean);
+  // Output reserve_space_4: Unused placeholder to match the variance input 
+  // in FusedBatchNorm.
+  std::shared_ptr<ng::Node> output_variance;
+  SaveNgOp(ng_op_map, op->name(), output_variance);
 
   return Status::OK();
 }

--- a/src/ngraph_mark_for_clustering.cc
+++ b/src/ngraph_mark_for_clustering.cc
@@ -267,8 +267,17 @@ Status MarkForClustering(Graph* graph) {
       confirmation_functions["FloorDiv"] = SimpleConfirmationFunction();
       confirmation_functions["FloorMod"] = SimpleConfirmationFunction();
       confirmation_functions["FusedBatchNorm"] = SimpleConfirmationFunction();
-      confirmation_functions["FusedBatchNormGrad"] =
-          SimpleConfirmationFunction();
+      confirmation_functions["FusedBatchNormGrad"] = [](Node* n, bool* result) {
+        // Reject if "is_training" is set false.
+        bool tf_is_training;
+        TF_RETURN_IF_ERROR( 
+            GetNodeAttr(n->attrs(), "new_axis_mask", &tf_is_training));
+        if (!tf_is_training) {
+          *result = false;
+          return Status::OK();
+        }
+          SimpleConfirmationFunction()(n, result);
+      };
       confirmation_functions["Greater"] = SimpleConfirmationFunction();
       confirmation_functions["GreaterEqual"] = SimpleConfirmationFunction();
       confirmation_functions["Identity"] = SimpleConfirmationFunction();

--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -158,8 +158,7 @@ TEST(NNOps, Conv2DBackpropFilterNHWC) {
 
 // Test Op :"Op_L2Loss"
 TEST(NNOps, Op_L2Loss) {
-
-  std::vector<std::vector<int64> > input_sizes;
+  std::vector<std::vector<int64>> input_sizes;
   input_sizes.push_back({2, 3, 4});
   input_sizes.push_back({0});
 
@@ -174,7 +173,7 @@ TEST(NNOps, Op_L2Loss) {
     auto R = ops::L2Loss(root, input_data);
     vector<DataType> output_datatypes = {DT_FLOAT};
     std::vector<Output> sess_run_fetchoutputs = {R};
-    
+
     OpExecuter opexecuter(root, "L2Loss", static_input_indexes,
                           output_datatypes, sess_run_fetchoutputs);
 

--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -54,16 +54,17 @@ namespace testing {
 
 // The backword operation for "BiasAdd" on the bias tensor.
 // NHWC: out_backprop input at least rank 2
-// NCHW: out_backprop input only rank 4 
+// NCHW: out_backprop input only rank 4
 TEST(NNOps, BiasAddGrad) {
   // define the shape for the out_backprop input shape
-  vector<int64> out_backprop_shape_2D = {10,20}; 
-  vector<int64> out_backprop_shape_3D = {1,3,6}; 
-  vector<int64> out_backprop_shape_4D = {1,2,3,4}; // NCHW only supports 4D input/output 
-  vector<int64> out_backprop_shape_5D = {2,4,6,8,10}; 
+  vector<int64> out_backprop_shape_2D = {10, 20};
+  vector<int64> out_backprop_shape_3D = {1, 3, 6};
+  vector<int64> out_backprop_shape_4D = {
+      1, 2, 3, 4};  // NCHW only supports 4D input/output
+  vector<int64> out_backprop_shape_5D = {2, 4, 6, 8, 10};
 
   vector<vector<int64>> shape_vector;
-  vector<int64> value_vector; 
+  vector<int64> value_vector;
 
   shape_vector.push_back(out_backprop_shape_2D);
   shape_vector.push_back(out_backprop_shape_3D);
@@ -75,14 +76,14 @@ TEST(NNOps, BiasAddGrad) {
   value_vector.push_back(-0.0003f);
   value_vector.push_back(29.09f);
 
-  // op has one attribute : data_format 
+  // op has one attribute : data_format
   auto attrs = ops::BiasAddGrad::Attrs();
-  attrs.data_format_ = "NHWC";  
+  attrs.data_format_ = "NHWC";
 
-  vector<int> static_input_indexes = {}; 
+  vector<int> static_input_indexes = {};
   vector<DataType> output_datatypes = {DT_FLOAT};
 
-   for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; i++) {
     Scope root = Scope::NewRootScope();
     auto tensor_shape = shape_vector[i];
     auto tensor_value = value_vector[i];
@@ -91,25 +92,25 @@ TEST(NNOps, BiasAddGrad) {
     AssignInputValues(out_backprop, tensor_value);
 
     auto R = ops::BiasAddGrad(root, out_backprop, attrs);
-    std::vector<Output> sess_run_fetchoutputs = {R}; // tf session run parameter
-    OpExecuter opexecuter(root, "BiasAddGrad",
-                        static_input_indexes, output_datatypes,
-                        sess_run_fetchoutputs);  
+    std::vector<Output> sess_run_fetchoutputs = {
+        R};  // tf session run parameter
+    OpExecuter opexecuter(root, "BiasAddGrad", static_input_indexes,
+                          output_datatypes, sess_run_fetchoutputs);
     opexecuter.RunTest();
   }
 
-  attrs.data_format_ = "NCHW"; 
+  attrs.data_format_ = "NCHW";
   Scope s_nchw = Scope::NewRootScope();
 
   Tensor out_backprop_4D(DT_FLOAT, TensorShape(out_backprop_shape_4D));
   AssignInputValues(out_backprop_4D, 0.99f);
 
   auto R_4D = ops::BiasAddGrad(s_nchw, out_backprop_4D, attrs);
-  std::vector<Output> sess_run_fetchoutputs_4D = {R_4D}; // tf session run parameter
-  OpExecuter opexecuter_4D(s_nchw, "BiasAddGrad",
-                        static_input_indexes, output_datatypes,
-                        sess_run_fetchoutputs_4D);  
-  
+  std::vector<Output> sess_run_fetchoutputs_4D = {
+      R_4D};  // tf session run parameter
+  OpExecuter opexecuter_4D(s_nchw, "BiasAddGrad", static_input_indexes,
+                           output_datatypes, sess_run_fetchoutputs_4D);
+
   opexecuter_4D.RunTest();
 }
 
@@ -155,7 +156,7 @@ TEST(NNOps, Conv2DBackpropFilterNHWC) {
   }
 }
 
-// Computes softmax cross entropy cost and gradients to backpropagate. 
+// Computes softmax cross entropy cost and gradients to backpropagate.
 TEST(NNOps, SparseSoftmaxCrossEntropyWithLogits) {
   Scope root = Scope::NewRootScope();
   int batch = 10;
@@ -179,9 +180,6 @@ TEST(NNOps, SparseSoftmaxCrossEntropyWithLogits) {
 
   opexecuter.RunTest();
 }
-
-
-
 
 }  // namespace testing
 

--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -194,21 +194,21 @@ TEST(NNOps, FusedBatchNormGrad_NHWC) {
   opexecuter.RunTest();
 
   // To do: runs on TF and gives error when running on NGRAPH
-  // Scope all_output_test = Scope::NewRootScope();
-  // vector<DataType> output_datatypes_all = {DT_FLOAT, DT_FLOAT,
-  // DT_FLOAT,DT_FLOAT,DT_FLOAT};
-  // R = ops::FusedBatchNormGrad(all_output_test, y_backprop, x, scale,
-  // reserve_space_1_mean,
-  //                             reserve_space_2_varience, attrs);
-  // std::vector<Output> sess_run_fetchoutputs_all = {R.x_backprop,
-  // R.scale_backprop,
-  //                                                   R.offset_backprop,R.reserve_space_3,
-  //                                                   R.reserve_space_4};
-  // OpExecuter opexecuter_all_output(all_output_test, "FusedBatchNormGrad",
-  // static_input_indexes,
-  //                       output_datatypes_all, sess_run_fetchoutputs_all);
-  // opexecuter_all_output.RunTest();
-  // opexecuter_all_output.ExecuteOnTF();
+  Scope all_output_test = Scope::NewRootScope();
+  vector<DataType> output_datatypes_all = {DT_FLOAT, DT_FLOAT,
+  DT_FLOAT,DT_FLOAT,DT_FLOAT};
+  R = ops::FusedBatchNormGrad(all_output_test, y_backprop, x, scale,
+  reserve_space_1_mean,
+                              reserve_space_2_varience, attrs);
+  std::vector<Output> sess_run_fetchoutputs_all = {R.x_backprop,
+  R.scale_backprop,
+                                                    R.offset_backprop,R.reserve_space_3,
+                                                    R.reserve_space_4};
+  OpExecuter opexecuter_all_output(all_output_test, "FusedBatchNormGrad",
+  static_input_indexes,
+                        output_datatypes_all, sess_run_fetchoutputs_all);
+  opexecuter_all_output.RunTest();
+  opexecuter_all_output.ExecuteOnTF();
 
   // To do : Fail right now
 

--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -156,6 +156,32 @@ TEST(NNOps, Conv2DBackpropFilterNHWC) {
   }
 }
 
+// Test Op :"Op_L2Loss"
+TEST(NNOps, Op_L2Loss) {
+
+  std::vector<std::vector<int64> > input_sizes;
+  input_sizes.push_back({2, 3, 4});
+  input_sizes.push_back({0});
+
+  vector<int> static_input_indexes = {};
+
+  for (auto const& input_size : input_sizes) {
+    Scope root = Scope::NewRootScope();
+
+    Tensor input_data(DT_FLOAT, TensorShape(input_size));
+    AssignInputValues(input_data, 0.0);
+
+    auto R = ops::L2Loss(root, input_data);
+    vector<DataType> output_datatypes = {DT_FLOAT};
+    std::vector<Output> sess_run_fetchoutputs = {R};
+    
+    OpExecuter opexecuter(root, "L2Loss", static_input_indexes,
+                          output_datatypes, sess_run_fetchoutputs);
+
+    opexecuter.RunTest();
+  }
+}
+
 // Computes softmax cross entropy cost and gradients to backpropagate.
 TEST(NNOps, SparseSoftmaxCrossEntropyWithLogits) {
   Scope root = Scope::NewRootScope();

--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -184,17 +184,31 @@ TEST(NNOps, FusedBatchNormGrad_NHWC) {
 
   vector<int> static_input_indexes = {};
   vector<DataType> output_datatypes = {DT_FLOAT, DT_FLOAT, DT_FLOAT};
-
   auto R =
       ops::FusedBatchNormGrad(root, y_backprop, x, scale, reserve_space_1_mean,
                               reserve_space_2_varience, attrs);
   std::vector<Output> sess_run_fetchoutputs = {R.x_backprop, R.scale_backprop,
                                                R.offset_backprop};
-
   OpExecuter opexecuter(root, "FusedBatchNormGrad", static_input_indexes,
                         output_datatypes, sess_run_fetchoutputs);
-
   opexecuter.RunTest();
+
+  // To do: runs on TF and gives error when running on NGRAPH
+  // Scope all_output_test = Scope::NewRootScope();
+  // vector<DataType> output_datatypes_all = {DT_FLOAT, DT_FLOAT,
+  // DT_FLOAT,DT_FLOAT,DT_FLOAT};
+  // R = ops::FusedBatchNormGrad(all_output_test, y_backprop, x, scale,
+  // reserve_space_1_mean,
+  //                             reserve_space_2_varience, attrs);
+  // std::vector<Output> sess_run_fetchoutputs_all = {R.x_backprop,
+  // R.scale_backprop,
+  //                                                   R.offset_backprop,R.reserve_space_3,
+  //                                                   R.reserve_space_4};
+  // OpExecuter opexecuter_all_output(all_output_test, "FusedBatchNormGrad",
+  // static_input_indexes,
+  //                       output_datatypes_all, sess_run_fetchoutputs_all);
+  // opexecuter_all_output.RunTest();
+  // opexecuter_all_output.ExecuteOnTF();
 
   // To do : Fail right now
 

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -66,6 +66,16 @@ void AssignInputValues(Tensor& A, float x) {
   }
 }
 
+// Input x will be used as an anchor
+// Actual value assigned equals to x * i
+void AssignInputValuesAnchor(Tensor& A, float x) {
+  auto A_flat = A.flat<float>();
+  auto A_flat_data = A_flat.data();
+  for (int i = 0; i < A_flat.size(); i++) {
+    A_flat_data[i] = x * i;
+  }
+}
+
 void PrintTensor(const Tensor& T1) {
   LOG(INFO) << "print tensor values" << T1.DebugString();
 }

--- a/test/test_utilities.h
+++ b/test/test_utilities.h
@@ -35,6 +35,7 @@ void DeactivateNGraph();
 void AssertTensorEquals(Tensor& T1, Tensor& T2);
 void AssignInputIntValues(Tensor& A, int maxval);
 void AssignInputValues(Tensor& A, float x);
+void AssignInputValuesAnchor(Tensor& A, float x);  // value assigned = x * index
 void PrintTensor(const Tensor& T1);
 void ValidateTensorData(Tensor& T1, Tensor& T2, float tol);
 


### PR DESCRIPTION
Add two additional outputs in FusedBatchNormGrad op to match the Tensorflow output.
Mark `is_training=False` as a rejection for FusedBatchNormGrad op.