### PR TITLE
Mingshan/Support UINT16 and enable the NCF to run with NGRAPH

### DIFF
--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -191,6 +191,8 @@ class NGraphEncapsulateOp : public OpKernel {
         TensorDataToStream<uint8>(ostream, n_elements, data);
         break;
       case DT_UINT16:
+        TensorDataToStream<uint16>(ostream, n_elements, data);
+        break;
       case DT_QUINT16:
         TensorDataToStream<uint16>(ostream, n_elements, data);
         break;

--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -191,8 +191,6 @@ class NGraphEncapsulateOp : public OpKernel {
         TensorDataToStream<uint8>(ostream, n_elements, data);
         break;
       case DT_UINT16:
-        TensorDataToStream<uint16>(ostream, n_elements, data);
-        break;
       case DT_QUINT16:
         TensorDataToStream<uint16>(ostream, n_elements, data);
         break;

--- a/src/ngraph_utils.cc
+++ b/src/ngraph_utils.cc
@@ -105,6 +105,9 @@ Status TFDataTypeToNGraphElementType(DataType tf_dt,
     case DataType::DT_UINT8:
       *ng_et = ng::element::u8;
       break;
+    case DataType::DT_UINT16:
+      *ng_et = ng::element::u16;
+      break;
     case DataType::DT_INT64:
       *ng_et = ng::element::i64;
       break;


### PR DESCRIPTION
Added small change to support UINT16 data type on NGRAPH.

Tested with the NCF model, both the training and inference runs with NGRAPH. 