### PR TITLE
CI script changes from r0.4 that need to be on master

### DIFF
--- a/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
+++ b/test/ci/docker/docker-run-ngraph-tf-cmdline.sh
@@ -66,7 +66,7 @@ fi
 # Set defaults
 
 if [ -z "${NG_TF_RUN_TYPE}" ] ; then
-    NG_TF_RUN_TYPE='ngraph'  # Default is to run with ngraph
+    NG_TF_RUN_TYPE='ngraph-tf'  # Default is to run with ngraph
 fi
 
 if [ -z "${NG_TF_PY_VERSION}" ] ; then


### PR DESCRIPTION
The only change I could find on "r0.4" that needed to be ported to master was a default run-type for ngraph-tf model testing.  This is a pretty minor change, but will help when doing debugging directly in the ngraph-tf repo.