### PR TITLE
Fix Python3 daily-build, plus balance Dockerfile additions

### DIFF
--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -65,7 +65,7 @@ if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
     bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
 fi
 
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
+if [[ "2" == "${PYTHON_VERSION}" ]]; then
     declare YAPF_FORMAT_PROG
     if ! YAPF_FORMAT_PROG="$(which "${YAPF_FORMAT_BASENAME}")"; then
         bash_lib_die "Unable to find program ${YAPF_FORMAT_BASENAME}" >&2

--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
@@ -54,6 +54,7 @@ RUN updatedb
 # keras_applications is needed for modern TensorFlow builds
 # matplotlib are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
+# yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip install --upgrade pip
 RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
@@ -61,7 +62,6 @@ RUN pip install keras_applications
 RUN pip install matplotlib opencv-python
 RUN pip install yapf
 RUN pip install futures
-
 
 # We include pytest so the Docker image can be used for daily validation
 RUN pip install --upgrade pytest

--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
@@ -54,11 +54,14 @@ RUN updatedb
 # keras_applications is needed for modern TensorFlow builds
 # matplotlib are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
+# yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip3 install --upgrade pip
 RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications
 RUN pip3 install matplotlib opencv-python
+RUN pip3 install yapf
+RUN pip3 install futures
 
 # We include pytest so the Docker image can be used for daily validation
 RUN pip3 install --upgrade pytest


### PR DESCRIPTION
ngraph-tf PR#211 made additions to the Dockerfile used for Python 2 builds in CI.  A small bug in this PR caused the Python 3 builds (in ngraph-tf-daily-build) to break when the Python package "yapf" could not be found.

This PR does two specific actions:

1. Fix the bug, as per @sayantan-nervana 's suggestion

1. Balance the Dockerfiles for both Py2 and Py3, by having both "yapf" and "futures" added to both.  In addition, include a comment in the Dockerfiles explaining how these additions are used.

Successful testing of this patch:
ngraph-tf-daily-build: https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/263/