### PR TITLE
Mingshan/Fix the ci test not running issue

### DIFF
--- a/test/ci/run-premerge-ci-checks.sh
+++ b/test/ci/run-premerge-ci-checks.sh
@@ -72,6 +72,7 @@ pushd ${BUILD_DIR}
 rm -rf benchmarks
 git clone https://github.com/tensorflow/benchmarks.git
 pushd benchmarks/scripts/tf_cnn_benchmarks/
+git checkout 4c7b09ad87bbfc4b1f89650bcee40b3fc5e7dfed
 echo "import ngraph" >> convnet_builder.py
 export JUNIT_WRAP_FILE="${BUILD_DIR}/junit_resnet50_imagenet_inference.xml"
 export JUNIT_WRAP_SUITE='inference_validation'


### PR DESCRIPTION
tensorflow benchmark/ repo added XLA to their codebase today and it makes our ci failed right now.

Added a fix by checkouting a previous commit. 