### PR TITLE
Add more packages to Dockerfile for additions to daily inference model runs

### DIFF
--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
@@ -52,14 +52,14 @@ RUN updatedb
 # six, enum34 and mock are required for building the tensorflow wheel
 # scipy, portpicker, and sklearn are needed by some TensorFlow tests
 # keras_applications is needed for modern TensorFlow builds
-# matplotlib are needed to run inference models
+# matplotlib and librosa are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
 # yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip install --upgrade pip
 RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
 RUN pip install keras_applications
-RUN pip install matplotlib opencv-python
+RUN pip install matplotlib librosa opencv-python
 RUN pip install yapf
 RUN pip install futures
 

--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
@@ -52,14 +52,14 @@ RUN updatedb
 # six, enum34 and mock are required for building the tensorflow wheel
 # scipy, portpicker, and sklearn are needed by some TensorFlow tests
 # keras_applications is needed for modern TensorFlow builds
-# matplotlib are needed to run inference models
+# matplotlib and librosa are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
 # yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip3 install --upgrade pip
 RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications
-RUN pip3 install matplotlib opencv-python
+RUN pip3 install matplotlib librosa opencv-python
 RUN pip3 install yapf
 RUN pip3 install futures
 


### PR DESCRIPTION
The YoloV2 inference model requires an additional "librosa" python package to run.  I tried adding this as a "pip install librosa" in the command for the daily inference run, but encountered errors.  Thus, I am adding the package in the standard Dockerfiles for ngraph-tf.