### PR TITLE
Mingshan/Disable the conv2dbackprop pytest

### DIFF
--- a/test/ci/run-premerge-ci-checks.sh
+++ b/test/ci/run-premerge-ci-checks.sh
@@ -54,7 +54,6 @@ pushd python
 python -m pytest \
     test_abs.py \
     test_cast.py \
-    test_conv2dbackpropinput.py \
     test_resize_to_dynamic_shape.py \
     test_slice.py \
     test_sigmoidgrad.py \


### PR DESCRIPTION
The pytest conv2dbackpropinput.py is giving random failure that we need to debug further. And the pytest for this op is also gets constant folded, so we should write a C++ test for this op. 

Already created a JIRA issue to track this, for now, we should disable this python test case.