### PR TITLE
Add keras_preprocessing package to Dockerfiles, to fix broken TF builds

### DIFF
--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py2
@@ -51,14 +51,14 @@ RUN updatedb
 
 # six, enum34 and mock are required for building the tensorflow wheel
 # scipy, portpicker, and sklearn are needed by some TensorFlow tests
-# keras_applications is needed for modern TensorFlow builds
+# keras_applications and keras_preprocessing are needed for modern TensorFlow builds
 # matplotlib and librosa are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
 # yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip install --upgrade pip
 RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
-RUN pip install keras_applications
+RUN pip install keras_applications keras_preprocessing
 RUN pip install matplotlib librosa opencv-python
 RUN pip install yapf
 RUN pip install futures

--- a/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
+++ b/test/ci/docker/Dockerfile.ngraph-tf-ci-py3
@@ -53,14 +53,14 @@ RUN updatedb
 
 # six, enum34 and mock are required for building the tensorflow wheel
 # scipy, portpicker, and sklearn are needed by some TensorFlow tests
-# keras_applications is needed for modern TensorFlow builds
+# keras_applications and keras_preprocessing are needed for modern TensorFlow builds
 # matplotlib and librosa are needed to run inference models
 # opencv-python is used by some inference models (for import cv2)
 # yapf and futures are needed for code-format checks (ngraph-tf PR#211)
 RUN pip3 install --upgrade pip
 RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
-RUN pip3 install keras_applications
+RUN pip3 install keras_applications keras_preprocessing
 RUN pip3 install matplotlib librosa opencv-python
 RUN pip3 install yapf
 RUN pip3 install futures


### PR DESCRIPTION
As of v1.11.0, TensorFlow now seems to require the keras_preprocessing Python package in order to build.  This fix is being done quickly, as CI is not working.