### PR TITLE
Fix of tensor liveness issue

### DIFF
--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -517,6 +517,9 @@ class NGraphEncapsulateOp : public OpKernel {
 
  private:
   Graph m_graph;
+  static std::weak_ptr<ng::runtime::Backend> s_ng_backend_wptr;
+  std::shared_ptr<ng::runtime::Backend> m_ng_backend
+      GUARDED_BY(s_ng_backend_mutex);
   std::unordered_map<std::string, std::shared_ptr<ngraph::Function>>
       m_ng_functions;
   NgFunctionIOCache m_ng_function_input_cache_map;
@@ -525,9 +528,6 @@ class NGraphEncapsulateOp : public OpKernel {
   int m_ngraph_cluster;
   std::vector<bool> m_input_is_static;
 
-  static std::weak_ptr<ng::runtime::Backend> s_ng_backend_wptr;
-  std::shared_ptr<ng::runtime::Backend> m_ng_backend
-      GUARDED_BY(s_ng_backend_mutex);
   static std::string s_ng_backend_name;
   static mutex s_ng_backend_mutex;
 };


### PR DESCRIPTION
NNP backend requests that all its tensors must have been destroyed when the backend itself is destroyed. However, in tf-bridge there is some cache still holding this tensor, which can cause exception in some cases.
Fix it by changing of order of backend and caches in the class member section so that backend is created before cache and destroyed after cache was destroyed, when the argon tensors have been released.