### PR TITLE
Update TF wheel used for MacOS builds to 1.12.0rc1

### DIFF
--- a/test/ci/macos/run-ngraph-tf-mac-build.sh
+++ b/test/ci/macos/run-ngraph-tf-mac-build.sh
@@ -223,7 +223,7 @@ if [ -z "${tf_dir}" ] ; then
     # If installing into the OS, use:
     # sudo --preserve-env --set-home pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${WHEEL_FILE}"
     # Here we are installing into a virtual environment, so DO NOT USE SUDO!!!
-    pip install -U tensorflow
+    pip install -U tensorflow==1.12.0rc1
     set +x
 
 else 


### PR DESCRIPTION
Currently ngraph-tf cannot build with the release version of the Tensorflow wheel (1.11.0).  Instead, we must "pip install tensorflow=1.12.0rc1".  This PR makes that change for the MacOS builds.