### PR TITLE
Fix: trivial typo

### DIFF
--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -54,7 +54,7 @@ namespace ngraph_bridge {
 //           |
 //          N7
 //
-// If nodes N1, N2, N3, N4, N6, and N7 are all marked, but N6 is unmarked, the
+// If nodes N1, N2, N3, N4, N6, and N7 are all marked, but N5 is unmarked, the
 // clustering pass will assign nodes N1, N2, N3, and N4 to one cluster, and
 // nodes N6 and N7 to another.
 //


### PR DESCRIPTION
I found there is a trivial typo in comment on ngraph_assign_cluster.cc.
This patch fixes this.