### PR TITLE
Mingshan/Eliminates one additional transpose

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -1497,14 +1497,9 @@ static Status TranslateDepthToSpaceOp(
   auto reshaped =
       make_shared<ng::op::Reshape>(ng_input, ng_axis_order, ng_reshape_shape);
 
-  auto transposed = ng::builder::numpy_transpose(reshaped, ng_transpose_shape);
-
-  ng::AxisVector ng_axis_order_second_reshape(transposed->get_shape().size());
-  std::iota(ng_axis_order_second_reshape.begin(),
-            ng_axis_order_second_reshape.end(), 0);
-  auto final_reshape = make_shared<ng::op::Reshape>(
-      transposed, ng_axis_order_second_reshape, ng_output_shape);
-  SaveNgOp(ng_op_map, op->name(), final_reshape);
+  auto final_result = make_shared<ng::op::Reshape>(reshaped, ng_transpose_shape,
+                                                   ng_output_shape);
+  SaveNgOp(ng_op_map, op->name(), final_result);
 
   return Status::OK();
 }


### PR DESCRIPTION
The NGraph implementation of Reshape op can eliminate one additional transpose before the Reshape for DepthToSpace. Changes made based on @aprocter 's comments. 