### PR TITLE
Fix transformer-LT bug

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -3021,14 +3021,12 @@ static Status TranslateSoftmaxOp(
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_input));
 
   auto ng_input_shape = ng_input->get_shape();
-
   // We apply softmax on the 2nd dimension by following TF
   // And we restrict the softmax input argument to be 2D for now
   ng::AxisSet ng_axes_softmax;
   auto shape_size = ng_input_shape.size();
-
-  if (shape_size != 2) {
-    return errors::InvalidArgument("TF Softmax logits must be 2-dimensional");
+  if (shape_size < 1) {
+    return errors::InvalidArgument("TF Softmax logits must be >=1 dimension");
   }
 
   ng_axes_softmax.insert(1);

--- a/test/python/test_softmax.py
+++ b/test/python/test_softmax.py
@@ -45,3 +45,35 @@ class TestSoftmax(NgraphTest):
         sess_fn = lambda sess: sess.run((a), feed_dict={x: x_np})
         np.allclose(self.with_ngraph(sess_fn), self.without_ngraph(sess_fn))
         np.allclose(self.with_ngraph(sess_fn), expected)
+
+    def test_softmax_3d(self):
+        x = tf.placeholder(tf.float32, shape=(2, 3, 2))
+
+        # input value and expected value
+        x_np = np.random.rand(2, 3, 2)
+        one_only_on_dim = list(x_np.shape)
+        dim = len(x_np.shape) - 1
+        one_only_on_dim[dim] = 1
+        y_np = np.exp(x_np)
+        a_np = y_np / np.reshape(np.sum(y_np, dim), one_only_on_dim)
+        expected = a_np
+        a = tf.nn.softmax(x)
+        sess_fn = lambda sess: sess.run((a), feed_dict={x: x_np})
+        np.allclose(self.with_ngraph(sess_fn), self.without_ngraph(sess_fn))
+        np.allclose(self.with_ngraph(sess_fn), expected)
+
+    def test_softmax_4d(self):
+        x = tf.placeholder(tf.float32, shape=(2, 3, 2, 4))
+
+        # input value and expected value
+        x_np = np.random.rand(2, 3, 2, 4)
+        one_only_on_dim = list(x_np.shape)
+        dim = len(x_np.shape) - 1
+        one_only_on_dim[dim] = 1
+        y_np = np.exp(x_np)
+        a_np = y_np / np.reshape(np.sum(y_np, dim), one_only_on_dim)
+        expected = a_np
+        a = tf.nn.softmax(x)
+        sess_fn = lambda sess: sess.run((a), feed_dict={x: x_np})
+        np.allclose(self.with_ngraph(sess_fn), self.without_ngraph(sess_fn))
+        np.allclose(self.with_ngraph(sess_fn), expected)


### PR DESCRIPTION
The softmax op expected the dimension = 2 same as TF. But now the TF kernel
for softmax in TF has changed the constraint to >=1 so making that same
change in ngtf fixes the bug.