### PR TITLE
yapf 0.24.0 for clang-format-3.9 in Docker builds

### DIFF
--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
@@ -60,7 +60,7 @@ RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
 RUN pip install keras_applications keras_preprocessing
 RUN pip install matplotlib librosa opencv-python
-RUN pip install yapf
+RUN pip install yapf==0.24.0
 RUN pip install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py3
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py3
@@ -64,7 +64,7 @@ RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications keras_preprocessing
 RUN pip3 install matplotlib librosa opencv-python
-RUN pip3 install yapf
+RUN pip3 install yapf==0.24.0
 RUN pip3 install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_gcc48_py35
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_gcc48_py35
@@ -78,7 +78,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications keras_preprocessing
-RUN pip3 install yapf
+RUN pip3 install yapf==0.24.0
 RUN pip3 install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_py27
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_py27
@@ -61,7 +61,7 @@ RUN pip install --upgrade pip
 RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
 RUN pip install keras_applications keras_preprocessing
-RUN pip install yapf
+RUN pip install yapf==0.24.0
 RUN pip install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_py35
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.builds_ubuntu1604_py35
@@ -60,7 +60,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications keras_preprocessing
-RUN pip3 install yapf
+RUN pip3 install yapf==0.24.0
 RUN pip3 install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.inference_ubuntu1604_py27
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.inference_ubuntu1604_py27
@@ -60,7 +60,7 @@ RUN pip install six enum34 mock
 RUN pip install scipy portpicker sklearn
 RUN pip install keras_applications keras_preprocessing
 RUN pip install matplotlib librosa opencv-python
-RUN pip install yapf
+RUN pip install yapf==0.24.0
 RUN pip install futures
 
 # We include pytest so the Docker image can be used for daily validation

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.inference_ubuntu1604_py35
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.inference_ubuntu1604_py35
@@ -64,7 +64,7 @@ RUN pip3 install six enum34 mock
 RUN pip3 install scipy portpicker sklearn
 RUN pip3 install keras_applications keras_preprocessing
 RUN pip3 install matplotlib librosa opencv-python
-RUN pip3 install yapf
+RUN pip3 install yapf==0.24.0
 RUN pip3 install futures
 
 # We include pytest so the Docker image can be used for daily validation


### PR DESCRIPTION
Lock yapf at version 0.24.0, as clang-format-3.9 seems to not be able to work with newer versions of yapf

Successful testing: https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/394/