### PR TITLE
Modify Mac builds to use TensorFlow 1.12.0 for builds

### DIFF
--- a/test/ci/macos/run-ngraph-tf-mac-build.sh
+++ b/test/ci/macos/run-ngraph-tf-mac-build.sh
@@ -223,7 +223,7 @@ if [ -z "${tf_dir}" ] ; then
     # If installing into the OS, use:
     # sudo --preserve-env --set-home pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${WHEEL_FILE}"
     # Here we are installing into a virtual environment, so DO NOT USE SUDO!!!
-    pip install -U tensorflow==1.12.0rc2
+    pip install -U tensorflow==1.12.0
     set +x
 
 else 


### PR DESCRIPTION
Mac builds were still using "tensorflow==1.12.0rc2" for builds.  This PR updates them to use "tensorflow==1.12.0".

Successful testing: 
https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-mac-daily-build/86/