### PR TITLE
Get libplaidml from the plaidml package

### DIFF
--- a/python/CreatePipWhl.cmake
+++ b/python/CreatePipWhl.cmake
@@ -139,35 +139,6 @@ if (PYTHON)
             )
         ENDFOREACH()
 
-        if ("${NGRAPH_LIB_FILES};" MATCHES "/libplaidml_backend.dylib;")
-            execute_process(COMMAND
-                install_name_tool -change
-                libngraph.dylib
-                @loader_path/libngraph.dylib
-                ${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge/libplaidml_backend.dylib
-                RESULT_VARIABLE result
-                ERROR_VARIABLE ERR
-                ERROR_STRIP_TRAILING_WHITESPACE
-            )
-            if(${result})
-                message(FATAL_ERROR "Cannot update @loader_path")
-            endif()
-
-            message("Library: libplaidml.dylib")
-            execute_process(COMMAND
-                install_name_tool -change
-                @rpath/libplaidml.dylib
-                @loader_path/../plaidml/libplaidml.so
-                ${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge/libplaidml_backend.dylib
-                RESULT_VARIABLE result
-                ERROR_VARIABLE ERR
-                ERROR_STRIP_TRAILING_WHITESPACE
-            )
-            if(${result})
-                message(FATAL_ERROR "Cannot update @loader_path")
-            endif()
-        endif()
-
     endif()
 
     execute_process(

--- a/python/CreatePipWhl.cmake
+++ b/python/CreatePipWhl.cmake
@@ -153,10 +153,11 @@ if (PYTHON)
                 message(FATAL_ERROR "Cannot update @loader_path")
             endif()
 
+            message("Library: libplaidml.dylib")
             execute_process(COMMAND
                 install_name_tool -change
-                libplaidml.dylib
-                @loader_path/libplaidml.dylib
+                @rpath/libplaidml.dylib
+                @loader_path/../plaidml/libplaidml.so
                 ${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge/libplaidml_backend.dylib
                 RESULT_VARIABLE result
                 ERROR_VARIABLE ERR
@@ -165,23 +166,6 @@ if (PYTHON)
             if(${result})
                 message(FATAL_ERROR "Cannot update @loader_path")
             endif()
-
-            set(plaidml_lib_list
-                libplaidml.dylib
-            )
-
-            FOREACH(lib_file ${plaidml_lib_list})
-                message("Library: " ${lib_file})
-                execute_process(COMMAND
-                    install_name_tool -change
-                    @rpath/${lib_file}
-                    @loader_path/${lib_file}
-                    ${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge/libplaidml_backend.dylib
-                    RESULT_VARIABLE result
-                    ERROR_VARIABLE ERR
-                    ERROR_STRIP_TRAILING_WHITESPACE
-                )
-            ENDFOREACH()
         endif()
 
     endif()

--- a/python/ngraph_bridge/__init__.in.py
+++ b/python/ngraph_bridge/__init__.in.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function 
 
+import importlib
 import os
 import sys
 import time
@@ -109,6 +110,16 @@ ngraph_bridge_lib.ngraph_is_supported_backend.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_get_currently_set_backend_name.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_is_logging_placement.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_tf_version.restype = ctypes.c_char_p
+
+
+try:
+    importlib.import_module('plaidml.settings')
+    # Importing plaidml.settings -- if it exists -- will have read the
+    # user's settings and configured the runtime environment
+    # appropriately.
+except ImportError:
+    pass
+
 
 def enable():
   ngraph_bridge_lib.ngraph_enable()


### PR DESCRIPTION
With this change, the generated wheel doesn't have to include libplaidml itself in order for PlaidML to work; PlaidML can be installed separately, as long as the wheel contains libplaidml_backend (which is ngraph code).