### PR TITLE
Enabled ability to have attributes with the backend name

### DIFF
--- a/src/ngraph_backend_manager.cc
+++ b/src/ngraph_backend_manager.cc
@@ -80,7 +80,14 @@ unordered_set<string> BackendManager::GetSupportedBackendNames() {
 }
 
 bool BackendManager::IsSupportedBackend(string& backend_name) {
-  auto itr = BackendManager::ng_supported_backends_.find(backend_name);
+  // strip off attributes, IE:CPU becomes IE
+       auto colon = backend_name.find(":");
+       std::string backend = "";
+      if (colon != backend_name.npos)
+      {
+          backend = backend_name.substr(0, colon);
+      }
+  auto itr = BackendManager::ng_supported_backends_.find(backend);
   if (itr == BackendManager::ng_supported_backends_.end()) {
     return false;
   }


### PR DESCRIPTION
Currently the code doesn't all for strings like `GPU:0` to be passed because nGraph won't find a backend named `GPU:0` even if there is a backend name `GPU`. We need to strip off the attributes before doing the check.  I need this for my backend so that I can add attributes.  This is definitely needed for Multiple devices