### PR TITLE
Mingshan/Adding support for FusedBatchNormV2 on the bridge

### DIFF
--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -3982,6 +3982,7 @@ const static std::map<
         {"FloorDiv", TranslateFloorDivOp},
         {"FloorMod", TranslateFloorModOp},
         {"FusedBatchNorm", TranslateFusedBatchNormOp},
+        {"FusedBatchNormV2", TranslateFusedBatchNormOp},
         {"FusedBatchNormGrad", TranslateFusedBatchNormGradOp},
         {"Greater", TranslateBinaryOp<ngraph::op::Greater>},
         {"GreaterEqual", TranslateBinaryOp<ngraph::op::GreaterEq>},

--- a/src/ngraph_mark_for_clustering.cc
+++ b/src/ngraph_mark_for_clustering.cc
@@ -239,6 +239,8 @@ Status MarkForClustering(Graph* graph) {
       confirmation_function_map["FloorMod"] = SimpleConfirmationFunction();
       confirmation_function_map["FusedBatchNorm"] =
           SimpleConfirmationFunction();
+      confirmation_function_map["FusedBatchNormV2"] =
+          SimpleConfirmationFunction();
       confirmation_function_map["FusedBatchNormGrad"] = [](Node* n,
                                                            bool* result) {
         TF_RETURN_IF_ERROR(GetNodeAttr(n->attrs(), "is_training", result));
@@ -373,6 +375,9 @@ Status MarkForClustering(Graph* graph) {
       type_constraint_map["FloorDiv"]["T"] = NGraphNumericDTypes();
       type_constraint_map["FloorMod"]["T"] = NGraphNumericDTypes();
       type_constraint_map["FusedBatchNorm"]["T"] = NGraphNumericDTypes();
+      // TODO (mingshan): FusedBatchNormV2 supports DT_HALF,DT_BFLOAT16,
+      // DT_FLOAT
+      type_constraint_map["FusedBatchNormV2"]["T"] = {DT_FLOAT};
       type_constraint_map["FusedBatchNormGrad"]["T"] = NGraphNumericDTypes();
       type_constraint_map["Greater"]["T"] = NGraphDTypes();
       type_constraint_map["GreaterEqual"]["T"] = NGraphDTypes();


### PR DESCRIPTION
Added: Use the same translation function as FusedBatchNorm, since the only different between FusedBatchNorm and FusedBatchNormV2 is the supported input data type.

Also add a TODO comment in the type_constraint_map to support DT_HALF and DT_BFLOAT16 for FusedBatchNormV2 when NGraph supports those data type. 