### PR TITLE
Shrestha/ Dequantize Op is supported only in 'Scaled' mode. 

### DIFF
--- a/src/ngraph_mark_for_clustering.cc
+++ b/src/ngraph_mark_for_clustering.cc
@@ -229,7 +229,12 @@ Status MarkForClustering(Graph* graph) {
       confirmation_function_map["DepthwiseConv2dNative"] =
           SimpleConfirmationFunction();
       confirmation_function_map["DepthToSpace"] = SimpleConfirmationFunction();
-      confirmation_function_map["Dequantize"] = SimpleConfirmationFunction();
+      confirmation_function_map["Dequantize"] = [](Node* n, bool* result) {
+        string mode;
+        TF_RETURN_IF_ERROR(GetNodeAttr(n->attrs(), "mode", &mode));
+        *result = (mode.compare("SCALED") == 0);
+        return Status::OK();
+      };
       confirmation_function_map["Equal"] = SimpleConfirmationFunction();
       confirmation_function_map["Exp"] = SimpleConfirmationFunction();
       confirmation_function_map["ExpandDims"] = SimpleConfirmationFunction();

--- a/test/test_array_ops.cpp
+++ b/test/test_array_ops.cpp
@@ -159,6 +159,75 @@ TEST(ArrayOps, Dequantizei8) {
   opexecuter.RunTest();
 }  // end of test op Dequantizei8
 
+// Dequantize tests for values tested in tf test
+// dequantize_op_test.DequantizeOpTest.testBasicQint8 with 'Scaled' mode
+TEST(ArrayOps, Dequantizei8TF1) {
+  Scope root = Scope::NewRootScope();
+  int dim1 = 3;
+
+  Tensor A(DT_QINT8, TensorShape({dim1}));
+  AssignInputValues<qint8>(A, {-128, 0, 127});
+
+  auto attrs = ops::Dequantize::Attrs();
+  attrs.mode_ = "SCALED";
+
+  vector<int> static_input_indexes = {1, 2};
+  ops::Dequantize R = ops::Dequantize(root, A, -1.0f, 2.0f, attrs);
+
+  vector<DataType> output_datatypes = {DT_FLOAT};
+
+  std::vector<Output> sess_run_fetchoutputs = {R.output};
+  OpExecuter opexecuter(root, "Dequantize", static_input_indexes,
+                        output_datatypes, sess_run_fetchoutputs);
+
+  opexecuter.RunTest();
+}  // end of test op Dequantizei8TF1
+
+// The output values are close but do not pass the test
+TEST(ArrayOps, DISABLED_Dequantizei8TF2) {
+  Scope root = Scope::NewRootScope();
+  int dim1 = 3;
+
+  Tensor A(DT_QINT8, TensorShape({dim1}));
+  AssignInputValues<qint8>(A, {-2, 4, -17});
+
+  auto attrs = ops::Dequantize::Attrs();
+  attrs.mode_ = "SCALED";
+
+  vector<int> static_input_indexes = {1, 2};
+  ops::Dequantize R = ops::Dequantize(root, A, -5.0f, -3.0f, attrs);
+
+  vector<DataType> output_datatypes = {DT_FLOAT};
+
+  std::vector<Output> sess_run_fetchoutputs = {R.output};
+  OpExecuter opexecuter(root, "Dequantize", static_input_indexes,
+                        output_datatypes, sess_run_fetchoutputs);
+
+  opexecuter.RunTest();
+}  // end of test op Dequantizei8TF2
+
+TEST(ArrayOps, Dequantizei8TF3) {
+  Scope root = Scope::NewRootScope();
+  int dim1 = 4;
+
+  Tensor A(DT_QINT8, TensorShape({dim1}));
+  AssignInputValues<qint8>(A, {0, -4, 42, -108});
+
+  auto attrs = ops::Dequantize::Attrs();
+  attrs.mode_ = "SCALED";
+
+  vector<int> static_input_indexes = {1, 2};
+  ops::Dequantize R = ops::Dequantize(root, A, 5.0f, 40.0f, attrs);
+
+  vector<DataType> output_datatypes = {DT_FLOAT};
+
+  std::vector<Output> sess_run_fetchoutputs = {R.output};
+  OpExecuter opexecuter(root, "Dequantize", static_input_indexes,
+                        output_datatypes, sess_run_fetchoutputs);
+
+  opexecuter.RunTest();
+}  // end of test op Dequantizei8TF3
+
 // Test op: Dequantize
 // Dequantizes a tensor from u8 to float
 TEST(ArrayOps, Dequantizeu8) {


### PR DESCRIPTION
Rejecting all other modes in confirmation pass. Discovered while looking at the dequantize_op_test.DequantizeOpTest.testBasicQint8 test.

The test dequantize_op_test.DequantizeOpTest.testBasicQint8 cannot be included as it runs with "MIN_COMBINED" mode which is not supported by the backend.