### PR TITLE
Mingshan/Update the tolerance for Conv2DBackpropFilterNCHWValid

### DIFF
--- a/test/test_nn_ops.cpp
+++ b/test/test_nn_ops.cpp
@@ -289,7 +289,7 @@ TEST(NNOps, Conv2DBackpropFilterNCHWValid) {
   opexecuter_tf.ExecuteOnTF(tf_outputs);
 
   // Compare NGraph and TF Outputs
-  Compare(tf_outputs, ngraph_outputs);
+  Compare(tf_outputs, ngraph_outputs, 1e-05, 1e-05);
 }
 
 TEST(NNOps, Conv2DBackpropFilterNCHWValidWithDilation) {


### PR DESCRIPTION
Resolve an error reported by @crlishka: 
```
[ RUN      ] NNOps.Conv2DBackpropFilterNCHWValid
/home/dockuser/ngraph-tf/test/test_utilities.h:134: Failure
Value of: rt
  Actual: false
Expected: true
 TF output 0.25428009033203125
 NG output 0.25428265333175659
[  FAILED  ] NNOps.Conv2DBackpropFilterNCHWValid (9 ms)
```
So loose the tolerance for Conv2DBackpropFilterNCHWValid test case. 