### PR TITLE
Build ngraph-tf not only on Centos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ cmake_minimum_required(VERSION 3.1)
 
 project (ngraph_tensorflow_bridge CXX)
 
+if (UNIX AND NOT APPLE)
+    set(LINUX TRUE)
+endif()
+
 # set directory where the custom finders live
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -260,7 +264,7 @@ endif()
 set(NGRAPH_INSTALL_DIR ${NGRAPH_ARTIFACTS_DIR})
 
 
-if(OS_VERSION STREQUAL "\"centos\"")
+if(EXISTS ${NGRAPH_INSTALL_DIR}/lib64)
 	set(NGRAPH_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/lib64/${LIBNGRAPH_SO})
 else()
 	set(NGRAPH_IMPORTED_LOCATION ${NGRAPH_INSTALL_DIR}/lib/${LIBNGRAPH_SO})

--- a/python/CreatePipWhl.cmake
+++ b/python/CreatePipWhl.cmake
@@ -36,10 +36,10 @@ if (PYTHON)
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/python/ngraph_bridge)
 
     # Get the list of libraries we need for the Python pip package
-    # If we are building on CentOS then it's lib64 - else lib
+    # If we are building on a 64-bits OS then it's lib64 - else lib
     set(LIB_SUFFIX lib)
     if(NOT APPLE)
-        if(OS_VERSION STREQUAL "centos")
+        if(EXISTS ${NGTF_INSTALL_DIR}/lib64)
             set(LIB_SUFFIX lib64)
         endif()
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,25 +72,26 @@ target_include_directories(${LIB_NAME} PUBLIC "${NGRAPH_DEVICE_INCLUDE_PATH}")
 #------------------------------------------------------------------------------
 #installation 
 #------------------------------------------------------------------------------
+if (LINUX)
+    include(GNUInstallDirs)
+else()
+    set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
+
 if (DEFINED NGRAPH_TF_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX ${NGRAPH_TF_INSTALL_PREFIX})
 else()
     set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/../install/")
 endif()
 
-
-if(OS_VERSION STREQUAL "\"centos\"")
-	set(NGTF_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib64)
-else()
-	set(NGTF_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
-endif()
-
+set(NGTF_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 
 # First install the libngraph_bridge.so
 install(TARGETS ${LIB_NAME} DESTINATION "${NGTF_INSTALL_LIB_DIR}")  
 
 # Next install all the other prerequisites
-if(OS_VERSION STREQUAL "\"centos\"")
+if(EXISTS ${NGRAPH_INSTALL_DIR}/lib64)
 	install(DIRECTORY ${NGRAPH_INSTALL_DIR}/lib64/ DESTINATION "${NGTF_INSTALL_LIB_DIR}" )
 else()
 	install(DIRECTORY ${NGRAPH_INSTALL_DIR}/lib/ DESTINATION "${NGTF_INSTALL_LIB_DIR}" )


### PR DESCRIPTION
When ngraph-tf is being built on a 64-bits OS another than Centos,
the directory with libraries ('build/artifacts/lib64') could not be
found since CMakeLists.txt and *.cmake files make a reference to 'lib64'
if and only if the host OS is Centos:

if(OS_VERSION STREQUAL "\"centos\"")

But if the host OS is not Centos (SUSE for example), the condition is
always false and the 'lib' directory instead of 'lib64' will be
looked for. To fix the situation the condition is changed to something
similar to:

if(EXISTS ${NGRAPH_INSTALL_DIR}/lib64)

In order to create the right one of the 'build/install/lib64' or
'build/install/lib' directories, the 'GNUInstallDirs' CMake module is
used on the Linux platform (the idea is stolen from NGraph). The
'NGTF_INSTALL_LIB_DIR' option is set to
'${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}':

set(NGTF_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>