### PR TITLE
Sarkars/edge contraction logging

### DIFF
--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -466,8 +466,16 @@ Status AssignClusters(Graph* graph) {
       Node* src = edge->src();
       Node* dst = edge->dst();
 
+      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE1 " << dst->name() << "\n";
+      }
+
       if (!src->IsOp() || !dst->IsOp()) {
         continue;
+      }
+
+      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE2 " << dst->name() << "\n";
       }
 
       int src_index = cluster_map[src]->index;
@@ -483,6 +491,10 @@ Status AssignClusters(Graph* graph) {
               .push_back(EdgeNonContractionReasons::UNSUPPORTED);
         }
         continue;
+      }
+
+      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE2.5 " << dst->name() << "\n";
       }
 
 #if !defined(NGRAPH_TF_DISABLE_DEADNESS_CHECK)
@@ -518,6 +530,10 @@ Status AssignClusters(Graph* graph) {
       }
 #endif
 
+if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE3 " << dst->name() << "\n";
+      }
+
       // check if the edge can be constracted with respect to backend
       bool is_backend_ok = false;
       TF_RETURN_IF_ERROR(
@@ -535,6 +551,13 @@ Status AssignClusters(Graph* graph) {
         continue;
       }
 
+      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE4 " << dst->name() << "\n";
+        cout << src_index << " " << dst_index << "\n"; //23, 23
+        cout << gc.HasEdge(src_index, dst_index) << "\n";   // 0 (False)
+
+      }
+
       // Check if contracting the edge will lead to cycles
       // if not, MergeClusters
       if (gc.HasEdge(src_index, dst_index) &&
@@ -542,40 +565,57 @@ Status AssignClusters(Graph* graph) {
         MergeClusters(edge, cluster_map);
         // something changed
         changed = true;
+
+        if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE4 NOCYCLE" << dst->name() << "\n";
+      }
+
       } else {
+
+        if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE4 CYCLE :( " << dst->name() << "\n";
+      }
         if (collect_non_contracting_edge_info) {
           // either static input
           // or there exists a longer path, so contracting this edge causes
           // cycles
           std::vector<int32> static_inputs;
           GetStaticInputs(dst, &static_inputs);
+          if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+          std::cout << "XXX: " << ng::join(static_inputs) << "\n";
+          std::cout << "edge->dst_input(): " << edge->dst_input() << "\n";
+          }
           bool is_static = std::find(static_inputs.begin(), static_inputs.end(),
                                      edge->dst_input()) != static_inputs.end();
           if (is_static) {
-            ///////TODO: THIS AREA NEEDS SOME MORE THOUGHT
-            /*
             bool fed_by_const = src->type_string() == "Const";
-
-            if (fed_by_const && NodeIsMarkedForClustering(src)) {
-              auto num_neighbours = std::accumulate(src->out_nodes().begin(), src->out_nodes().end(), 0, [](int acc, tensorflow::Node* x){return acc+1;});
+            bool in_diff_clusters = src_index != dst_index;
+            auto num_neighbours_of_const = std::accumulate(src->out_nodes().begin(), src->out_nodes().end(), 0, [](int acc, tensorflow::Node* x){return acc+1;});
+            if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+            cout << fed_by_const << " " << in_diff_clusters << " " << num_neighbours_of_const << "\n";}
+            if (fed_by_const && NodeIsMarkedForClustering(src) && in_diff_clusters && num_neighbours_of_const==1) {
+              
               for (auto xx : src->out_nodes()){
-                std::cout << "HERE:: " << xx->name() << " " << xx->type_string() << "\n";
+                std::cout << "\n\nHERE:: " << xx->name() << " " << xx->type_string() << "\n";
               }
+              std::cout << "";
               return errors::Internal(
                   "A Const node ", src->name(),
                   " is feeding a static input in ", dst->name(),
                   ", but they are in different clusters. This "
-                  "should not be happening ", num_neighbours, NodeIsMarkedForClustering(src));
+                  "should not be happening ", num_neighbours_of_const, NodeIsMarkedForClustering(src));
             }
-            */
-           ///////
           }
           cluster_separation_reason[get_string_key(src_index, dst_index)]
               .push_back(is_static ? EdgeNonContractionReasons::STATICINPUT
                                    : EdgeNonContractionReasons::PATHEXISTS);
         }
       }
+      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
+        cout << "\nHEREHEREHERE5 " << dst->name() << "\n";
+      }
     }
+
 
     if (!changed && config::IsLoggingPlacement()) {
       // This will be entered only once if logging is enabled

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -562,14 +562,18 @@ Status AssignClusters(Graph* graph) {
       }
     }
 
-    if (!changed && config::IsLoggingPlacement() &&
-        !collect_non_contracting_edge_info) {
-      changed = true;
-      collect_non_contracting_edge_info = true;
+    if (!changed && config::IsLoggingPlacement()) {
+      if (!collect_non_contracting_edge_info) {
+        changed = true;
+        collect_non_contracting_edge_info = true;
+      } else {
+        if (changed) {
+          return errors::Internal(
+              "After contraction has finished, found changed to be true.");
+        }
+      }
     }
-    if (collect_non_contracting_edge_info) {
-      // assert "changed" is false
-    }
+
   } while (changed);
 
   NGRAPH_VLOG(2) << "Contraction done";
@@ -651,7 +655,7 @@ Status AssignClusters(Graph* graph) {
     int num_non_contracted = 0;
     std::vector<string> reason_string(
         {"UNSUPPORTED", "DEADNESS", "BACKEND", "STATICINPUT", "PATHEXISTS"});
-    std::cout << "Encapsulates i->j: non contraction reason (Cannot be "
+    std::cout << "_ngraph_cluster i->j: non contraction reason (Cannot be "
                  "UNSUPPORTED because unsupported ops will not be assigned an "
                  "encapsulate)\n";
     for (auto it : cluster_separation_reason) {

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -673,10 +673,11 @@ Status AssignClusters(Graph* graph) {
     std::vector<string> reason_string(  // to convert the enum to string
         {"NOTANOP", "UNSUPPORTED", "DEADNESS", "BACKEND", "SAMECLUSTER",
          "STATICINPUT", "PATHEXISTS"});
-    std::cout << "_ngraph_cluster i->j: non contraction reason (Cannot be "
-                 "UNSUPPORTED or NOTANOP because unsupported ops will not be "
-                 "assigned an "
-                 "encapsulate)\n";
+    std::cout
+        << "_ngraph_cluster i->j: non contraction reason histogram (Cannot be "
+           "UNSUPPORTED or NOTANOP because unsupported ops will not be "
+           "assigned an "
+           "encapsulate)\n";
     for (auto it : cluster_separation_reason) {
       num_non_contracted += it.second.size();
       vector<string> reasons_for_this_edge;
@@ -705,8 +706,13 @@ Status AssignClusters(Graph* graph) {
               "encapsulates",
               reasons_string);
         }
-        std::cout << src_encapsulate << "->" << dst_encapsulate << ": "
-                  << reasons_string << endl;
+        std::unordered_map<string, int> pair_reason_hist;
+        for (auto& i : ng::split(reasons_string, ',')) {
+          pair_reason_hist[i]++;
+        }
+        std::cout << src_encapsulate << "->" << dst_encapsulate << ": ";
+        print_node_histogram(pair_reason_hist);
+        std::cout << endl;
       }
     }
     for (auto& itr : deadness_info) {

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -581,11 +581,6 @@ Status AssignClusters(Graph* graph) {
       if (!collect_non_contracting_edge_info) {
         changed = true;
         collect_non_contracting_edge_info = true;
-      } else {
-        if (changed) {
-          return errors::Internal(
-              "After contraction has finished, found changed to be true.");
-        }
       }
     }
   } while (changed);

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -675,12 +675,6 @@ Status AssignClusters(Graph* graph) {
            "encapsulate)\n";
     for (auto it : cluster_separation_reason) {
       num_non_contracted += it.second.size();
-      // vector of reasons why 2 clusters were separated
-      vector<string> reasons_for_this_separation;
-      for (auto& inner_itr : it.second) {
-        reason_count[inner_itr]++;
-        reasons_for_this_separation.push_back(reason_string[inner_itr]);
-      }
       auto cluster_id_vector = ng::split(it.first, ',');
       // function to find if this cluster became an ngraph_cluster
       // returns ngraph_cluster id if yes, else returns -1
@@ -694,6 +688,12 @@ Status AssignClusters(Graph* graph) {
           src_encapsulate >= 0 && dst_encapsulate >= 0;
       bool src_dst_are_distinct = src_encapsulate != dst_encapsulate;
       if (both_src_dst_are_encapsulates && src_dst_are_distinct) {
+        // vector of reasons why 2 clusters were separated
+        vector<string> reasons_for_this_separation;
+        for (auto& inner_itr : it.second) {
+          reason_count[inner_itr]++;
+          reasons_for_this_separation.push_back(reason_string[inner_itr]);
+        }
         auto reasons_string = ng::join(reasons_for_this_separation);
         if (reasons_string.find(reason_string[0]) != std::string::npos) {
           return errors::Internal(

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -551,25 +551,6 @@ Status AssignClusters(Graph* graph) {
           GetStaticInputs(dst, &static_inputs);
           bool is_static = std::find(static_inputs.begin(), static_inputs.end(),
                                      edge->dst_input()) != static_inputs.end();
-          if (is_static) {
-            ///////TODO: THIS AREA NEEDS SOME MORE THOUGHT
-            /*
-            bool fed_by_const = src->type_string() == "Const";
-
-            if (fed_by_const && NodeIsMarkedForClustering(src)) {
-              auto num_neighbours = std::accumulate(src->out_nodes().begin(), src->out_nodes().end(), 0, [](int acc, tensorflow::Node* x){return acc+1;});
-              for (auto xx : src->out_nodes()){
-                std::cout << "HERE:: " << xx->name() << " " << xx->type_string() << "\n";
-              }
-              return errors::Internal(
-                  "A Const node ", src->name(),
-                  " is feeding a static input in ", dst->name(),
-                  ", but they are in different clusters. This "
-                  "should not be happening ", num_neighbours, NodeIsMarkedForClustering(src));
-            }
-            */
-           ///////
-          }
           cluster_separation_reason[get_string_key(src_index, dst_index)]
               .push_back(is_static ? EdgeNonContractionReasons::STATICINPUT
                                    : EdgeNonContractionReasons::PATHEXISTS);
@@ -701,7 +682,8 @@ Status AssignClusters(Graph* graph) {
           return errors::Internal(
               "UNSUPPORTED should not be a reason why 2 encapsulates did not "
               "merge, because unsupported ops would not end up in "
-              "encapsulates", reasons_string);
+              "encapsulates",
+              reasons_string);
         }
         std::cout << src_encapsulate << "->" << dst_encapsulate << ": "
                   << reasons_string << endl;

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -466,16 +466,8 @@ Status AssignClusters(Graph* graph) {
       Node* src = edge->src();
       Node* dst = edge->dst();
 
-      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE1 " << dst->name() << "\n";
-      }
-
       if (!src->IsOp() || !dst->IsOp()) {
         continue;
-      }
-
-      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE2 " << dst->name() << "\n";
       }
 
       int src_index = cluster_map[src]->index;
@@ -491,10 +483,6 @@ Status AssignClusters(Graph* graph) {
               .push_back(EdgeNonContractionReasons::UNSUPPORTED);
         }
         continue;
-      }
-
-      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE2.5 " << dst->name() << "\n";
       }
 
 #if !defined(NGRAPH_TF_DISABLE_DEADNESS_CHECK)
@@ -530,10 +518,6 @@ Status AssignClusters(Graph* graph) {
       }
 #endif
 
-if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE3 " << dst->name() << "\n";
-      }
-
       // check if the edge can be constracted with respect to backend
       bool is_backend_ok = false;
       TF_RETURN_IF_ERROR(
@@ -551,13 +535,6 @@ if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2
         continue;
       }
 
-      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE4 " << dst->name() << "\n";
-        cout << src_index << " " << dst_index << "\n"; //23, 23
-        cout << gc.HasEdge(src_index, dst_index) << "\n";   // 0 (False)
-
-      }
-
       // Check if contracting the edge will lead to cycles
       // if not, MergeClusters
       if (gc.HasEdge(src_index, dst_index) &&
@@ -565,57 +542,40 @@ if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2
         MergeClusters(edge, cluster_map);
         // something changed
         changed = true;
-
-        if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE4 NOCYCLE" << dst->name() << "\n";
-      }
-
       } else {
-
-        if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE4 CYCLE :( " << dst->name() << "\n";
-      }
         if (collect_non_contracting_edge_info) {
           // either static input
           // or there exists a longer path, so contracting this edge causes
           // cycles
           std::vector<int32> static_inputs;
           GetStaticInputs(dst, &static_inputs);
-          if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-          std::cout << "XXX: " << ng::join(static_inputs) << "\n";
-          std::cout << "edge->dst_input(): " << edge->dst_input() << "\n";
-          }
           bool is_static = std::find(static_inputs.begin(), static_inputs.end(),
                                      edge->dst_input()) != static_inputs.end();
           if (is_static) {
+            ///////TODO: THIS AREA NEEDS SOME MORE THOUGHT
+            /*
             bool fed_by_const = src->type_string() == "Const";
-            bool in_diff_clusters = src_index != dst_index;
-            auto num_neighbours_of_const = std::accumulate(src->out_nodes().begin(), src->out_nodes().end(), 0, [](int acc, tensorflow::Node* x){return acc+1;});
-            if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-            cout << fed_by_const << " " << in_diff_clusters << " " << num_neighbours_of_const << "\n";}
-            if (fed_by_const && NodeIsMarkedForClustering(src) && in_diff_clusters && num_neighbours_of_const==1) {
-              
+
+            if (fed_by_const && NodeIsMarkedForClustering(src)) {
+              auto num_neighbours = std::accumulate(src->out_nodes().begin(), src->out_nodes().end(), 0, [](int acc, tensorflow::Node* x){return acc+1;});
               for (auto xx : src->out_nodes()){
-                std::cout << "\n\nHERE:: " << xx->name() << " " << xx->type_string() << "\n";
+                std::cout << "HERE:: " << xx->name() << " " << xx->type_string() << "\n";
               }
-              std::cout << "";
               return errors::Internal(
                   "A Const node ", src->name(),
                   " is feeding a static input in ", dst->name(),
                   ", but they are in different clusters. This "
-                  "should not be happening ", num_neighbours_of_const, NodeIsMarkedForClustering(src));
+                  "should not be happening ", num_neighbours, NodeIsMarkedForClustering(src));
             }
+            */
+           ///////
           }
           cluster_separation_reason[get_string_key(src_index, dst_index)]
               .push_back(is_static ? EdgeNonContractionReasons::STATICINPUT
                                    : EdgeNonContractionReasons::PATHEXISTS);
         }
       }
-      if (src->name() == "ConstantFolding/tower_0/v/gradients/tower_0/v/cg/MobilenetV2/Conv_1/Conv2D_grad/ShapeN-matshapes-1"){
-        cout << "\nHEREHEREHERE5 " << dst->name() << "\n";
-      }
     }
-
 
     if (!changed && config::IsLoggingPlacement()) {
       // This will be entered only once if logging is enabled

--- a/src/ngraph_assign_clusters.cc
+++ b/src/ngraph_assign_clusters.cc
@@ -675,10 +675,11 @@ Status AssignClusters(Graph* graph) {
            "encapsulate)\n";
     for (auto it : cluster_separation_reason) {
       num_non_contracted += it.second.size();
-      vector<string> reasons_for_this_edge;
+      // vector of reasons why 2 clusters were separated
+      vector<string> reasons_for_this_separation;
       for (auto& inner_itr : it.second) {
         reason_count[inner_itr]++;
-        reasons_for_this_edge.push_back(reason_string[inner_itr]);
+        reasons_for_this_separation.push_back(reason_string[inner_itr]);
       }
       auto cluster_id_vector = ng::split(it.first, ',');
       // function to find if this cluster became an ngraph_cluster
@@ -693,7 +694,7 @@ Status AssignClusters(Graph* graph) {
           src_encapsulate >= 0 && dst_encapsulate >= 0;
       bool src_dst_are_distinct = src_encapsulate != dst_encapsulate;
       if (both_src_dst_are_encapsulates && src_dst_are_distinct) {
-        auto reasons_string = ng::join(reasons_for_this_edge);
+        auto reasons_string = ng::join(reasons_for_this_separation);
         if (reasons_string.find(reason_string[0]) != std::string::npos) {
           return errors::Internal(
               "UNSUPPORTED should not be a reason why 2 encapsulates did not "

--- a/src/ngraph_deassign_clusters.cc
+++ b/src/ngraph_deassign_clusters.cc
@@ -130,10 +130,7 @@ Status DeassignClusters(Graph* graph) {
   // When running unit tests, we do not want to see trivial clusters
   // deassigned. This flag (used by the Python tests) makes this possible.
   //
-  if (std::getenv("NGRAPH_TF_DISABLE_DEASSIGN_CLUSTERS") != nullptr) {
-    MaybeLogPlacement(graph);
-    return Status::OK();
-  }
+  if (std::getenv("NGRAPH_TF_DISABLE_DEASSIGN_CLUSTERS") == nullptr) {
 
   std::map<int, std::set<Node*>> cluster_map;
 
@@ -172,6 +169,7 @@ Status DeassignClusters(Graph* graph) {
         node->ClearAttr("_ngraph_marked_for_clustering");
       }
     }
+  }
   }
 
   //

--- a/src/ngraph_encapsulate_clusters.cc
+++ b/src/ngraph_encapsulate_clusters.cc
@@ -34,6 +34,7 @@
 #include "tensorflow/core/platform/protobuf.h"
 #include "tensorflow/core/util/device_name_utils.h"
 
+#include "ngraph_api.h"
 #include "ngraph_assign_clusters.h"
 #include "ngraph_cluster_manager.h"
 #include "ngraph_encapsulate_clusters.h"
@@ -148,12 +149,16 @@ Status EncapsulateClusters(Graph* graph) {
   // add inputs for them to the corresponding FunctionDef(s).
   std::map<int, int> retval_index_count;
   std::map<int, int> arg_index_count;
+  int count_arg = 0, count_retval = 0, count_both_arg_retval = 0,
+      count_free = 0, count_encapsulated = 0, count_tot = 0;
 
   for (auto edge : graph->edges()) {
+    count_tot++;
     // TODO(amprocte): should actually keep of these. During clustering we
     // will already have identified any intra-cluster control deps. Should
     // maintain inter-cluster control deps.
     if (edge->IsControlEdge()) {
+      count_free++;
       continue;
     }
 
@@ -163,6 +168,7 @@ Status EncapsulateClusters(Graph* graph) {
     // TODO(amprocte): the following rejects edges involving source/sink. Is
     // that what we want to do?
     if (!src->IsOp() || !dst->IsOp()) {
+      count_free++;
       continue;
     }
 
@@ -177,6 +183,7 @@ Status EncapsulateClusters(Graph* graph) {
     // Ignore edges within a cluster. (Note that this test also works when
     // both nodes are unclustered; GetNodeCluster gives us -1 in that case.
     if (dst_cluster_idx == src_cluster_idx) {
+      count_encapsulated++;
       continue;
     }
 
@@ -190,6 +197,8 @@ Status EncapsulateClusters(Graph* graph) {
                    << edge->src_output() << "] in " << src_cluster_idx << " to "
                    << dst->name() << "[" << edge->dst_input() << "] in "
                    << dst_cluster_idx << ", datatype: " << dt;
+
+    bool edge_is_retval = false, edge_is_arg = false;
 
     // If the source node lies within a cluster, we must create an output for
     // it from the source cluster. For the moment we will just store this
@@ -209,6 +218,7 @@ Status EncapsulateClusters(Graph* graph) {
           NGraphClusterManager::GetClusterGraph(src_cluster_idx)->add_node();
       new_output_node_def->set_name(output_name);
       new_output_node_def->set_op("_Retval");
+      edge_is_retval = true;
 
       std::stringstream ss_input_to_retval;
       ss_input_to_retval << src->name() << ":" << edge->src_output();
@@ -246,6 +256,7 @@ Status EncapsulateClusters(Graph* graph) {
           NGraphClusterManager::GetClusterGraph(dst_cluster_idx)->add_node();
       new_input_node_def->set_name(new_input_name);
       new_input_node_def->set_op("_Arg");
+      edge_is_arg = true;
 
       SetAttrValue(dt, &((*(new_input_node_def->mutable_attr()))["T"]));
       SetAttrValue(arg_index_count[dst_cluster_idx],
@@ -255,6 +266,36 @@ Status EncapsulateClusters(Graph* graph) {
 
       cluster_input_map[dst_cluster_idx].push_back(
           std::make_tuple(src->id(), edge->src_output(), dt));
+    }
+
+    if (config::IsLoggingPlacement()) {
+      if (edge_is_arg && edge_is_retval) {
+        count_both_arg_retval++;
+      } else {
+        if (edge_is_arg) {
+          count_arg++;
+        } else {
+          count_retval++;
+        }
+      }
+    }
+  }
+
+  if (config::IsLoggingPlacement()) {
+    int computed_edge_number = count_arg + count_retval +
+                               count_both_arg_retval + count_free +
+                               count_encapsulated;
+    std::cout << "NGTF_SUMMARY: Types of edges:: args: " << count_arg
+              << ", retvals: " << count_retval
+              << ", both arg and retval: " << count_both_arg_retval
+              << ", free: " << count_free
+              << ", encapsulated: " << count_encapsulated
+              << ", total: " << count_tot
+              << ", computed total: " << computed_edge_number << endl;
+    if (computed_edge_number != count_tot) {
+      return errors::Internal("Computed number of edges ", computed_edge_number,
+                              " and counted number of edges ", count_tot,
+                              " do not match up\n");
     }
   }
 

--- a/src/ngraph_encapsulate_clusters.cc
+++ b/src/ngraph_encapsulate_clusters.cc
@@ -296,7 +296,8 @@ Status EncapsulateClusters(Graph* graph) {
           count_tot == graph->num_edges())) {
       return errors::Internal("Computed number of edges ", computed_edge_number,
                               " and counted number of edges ", count_tot,
-                              " do not match up\n");
+                              " and number of edges from querying TF api ",
+                              graph->num_edges(), " do not match up\n");
     }
   }
 

--- a/src/ngraph_encapsulate_clusters.cc
+++ b/src/ngraph_encapsulate_clusters.cc
@@ -292,7 +292,8 @@ Status EncapsulateClusters(Graph* graph) {
               << ", encapsulated: " << count_encapsulated
               << ", total: " << count_tot
               << ", computed total: " << computed_edge_number << endl;
-    if (computed_edge_number != count_tot) {
+    if (!(computed_edge_number == count_tot &&
+          count_tot == graph->num_edges())) {
       return errors::Internal("Computed number of edges ", computed_edge_number,
                               " and counted number of edges ", count_tot,
                               " do not match up\n");


### PR DESCRIPTION
it prints:
```
src_encapsulate_id->dst_encapsulate_id: reason
src_encapsulate_id->dst_encapsulate_id: reason
src_encapsulate_id->dst_encapsulate_id: reason
src_encapsulate_id->dst_encapsulate_id: reason

predicates of stuff not merging due to deadness

NGTF_SUMMARY: Ratio of uncontracted edges: x/y = z
NGTF_SUMMARY: UNSUPPORTED: 8, DEADNESS: 1, BACKEND: 0, STATICINPUT: 0, PATHEXISTS: 3
```


Sample output when `NGRAPH_TF_LOG_PLACEMENT=1 ./test/gtest_ngtf --gtest_filter="*DeadnessCheck.livedead1"` is run:


```
=============Edge contraction logs=============
Encapsulates i->j non contraction reason: (Cannot be UNSUPPORTED because unsupported ops will not be assigned an encapsulate)
0->1: DEADNESS
Source predicate: #true Destination predicate: predS:0 Neighbours predicates: #control_flow

NGTF_SUMMARY: Ratio of uncontracted edges: 12/19 = 0.631579
NGTF_SUMMARY: UNSUPPORTED: 8, DEADNESS: 1, BACKEND: 0, STATICINPUT: 0, PATHEXISTS: 3
```