### PR TITLE
Add ngraph-tf plaidml extra dep

### DIFF
--- a/python/setup.in.py
+++ b/python/setup.in.py
@@ -56,4 +56,7 @@ setup(
         ],
     },
     cmdclass={'bdist_wheel': BinaryBdistWheel},
+    extras_require={
+        'plaidml': ["plaidml>=0.5.0"],
+    },
 )


### PR DESCRIPTION
So check this out--this makes it easy to optionally install ngraph-tf w/PlaidML as a single step, by adding `[plaidml]` to the install command:

(ngraph-tf-test)
rearhart@rearhart-mac01 ~/src/ngraph-tf/build (master)
$ pip install python/dist/ngraph_tensorflow_bridge-0.10.0-py2.py3-none-macosx_10_7_x86_64.whl
Processing ./python/dist/ngraph_tensorflow_bridge-0.10.0-py2.py3-none-macosx_10_7_x86_64.whl
Installing collected packages: ngraph-tensorflow-bridge
Successfully installed ngraph-tensorflow-bridge-0.10.0

(ngraph-tf-test)
rearhart@rearhart-mac01 ~/src/ngraph-tf/build (master)
$ conda list
\# packages in environment at /Users/rearhart/miniconda3/envs/ngraph-tf-test:
\#
\# Name                    Version                   Build  Channel
ca-certificates           2018.12.5                     0
certifi                   2018.11.29               py37_0
libcxx                    4.0.1                hcfea43d_1
libcxxabi                 4.0.1                hcfea43d_1
libedit                   3.1.20181209         hb402a30_0
libffi                    3.2.1                h475c297_4
ncurses                   6.1                  h0a44026_1
ngraph-tensorflow-bridge  0.10.0                    &lt;pip&gt;
openssl                   1.1.1a               h1de35cc_0
pip                       19.0.1                   py37_0
python                    3.7.2                haf84260_0
readline                  7.0                  h1de35cc_5
setuptools                40.7.3                   py37_0
sqlite                    3.26.0               ha441bb4_0
tk                        8.6.8                ha441bb4_0
wheel                     0.32.3                   py37_0
xz                        5.2.4                h1de35cc_4
zlib                      1.2.11               h1de35cc_3

(ngraph-tf-test)
rearhart@rearhart-mac01 ~/src/ngraph-tf/build (master)
$ pip install python/dist/ngraph_tensorflow_bridge-0.10.0-py2.py3-none-macosx_10_7_x86_64.whl[plaidml]
Requirement already satisfied: ngraph-tensorflow-bridge==0.10.0 from file:///Users/rearhart/src/ngraph-tf/build/python/dist/ngraph_tensorflow_bridge-0.10.0-py2.py3-none-macosx_10_7_x86_64.whl in /Users/rearhart/miniconda3/envs/ngraph-tf-test/lib/python3.7/site-packages (0.10.0)
Collecting plaidml>=0.5.0; extra == "plaidml" (from ngraph-tensorflow-bridge==0.10.0)
  Downloading https://files.pythonhosted.org/packages/99/de/e1953313d8bba57e2445201e858d727a5d997495b790773bb440b771a3f1/plaidml-0.5.0-py2.py3-none-macosx_10_10_x86_64.whl (11.4MB)
    100% |████████████████████████████████| 11.4MB 2.2MB/s
Collecting numpy (from plaidml>=0.5.0; extra == "plaidml"->ngraph-tensorflow-bridge==0.10.0)
  Downloading https://files.pythonhosted.org/packages/46/e4/4a0cc770e4bfb34b4e10843805fef67b9a94027e59162a586c776f35c5bb/numpy-1.16.1-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (13.9MB)
    100% |████████████████████████████████| 13.9MB 1.4MB/s
Collecting six (from plaidml>=0.5.0; extra == "plaidml"->ngraph-tensorflow-bridge==0.10.0)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting enum34>=1.1.6 (from plaidml>=0.5.0; extra == "plaidml"->ngraph-tensorflow-bridge==0.10.0)
  Using cached https://files.pythonhosted.org/packages/af/42/cb9355df32c69b553e72a2e28daee25d1611d2c0d9c272aa1d34204205b2/enum34-1.1.6-py3-none-any.whl
Installing collected packages: numpy, six, enum34, plaidml
Successfully installed enum34-1.1.6 numpy-1.16.1 plaidml-0.5.0 six-1.12.0