### PR TITLE
Fix the unit test failure on Mac

### DIFF
--- a/src/ngraph_utils.cc
+++ b/src/ngraph_utils.cc
@@ -255,14 +255,16 @@ void MemoryProfile(long& vm_usage, long& resident_set) {
   std::ifstream ifs("/proc/self/stat", std::ios_base::in);
   std::string mem_in;
   getline(ifs, mem_in);
-  vector<string> mem_str = ng::split(mem_in, ' ');
-  vsize = std::stol(mem_str[22]);
-  rss = std::stol(mem_str[23]);
+  if(mem_in != "") {
+    vector<string> mem_str = ng::split(mem_in, ' ');
+    vsize = std::stol(mem_str[22]);
+    rss = std::stol(mem_str[23]);
 
-  long page_size_kb = sysconf(_SC_PAGE_SIZE) /
+    long page_size_kb = sysconf(_SC_PAGE_SIZE) /
                       1024;  // in case x86-64 is configured to use 2MB pages
-  vm_usage = vsize / 1024;   // unit kb
-  resident_set = rss * page_size_kb;
+    vm_usage = vsize / 1024;   // unit kb
+    resident_set = rss * page_size_kb;
+  }
 };
 
 }  // namespace ngraph_bridge

--- a/src/ngraph_utils.cc
+++ b/src/ngraph_utils.cc
@@ -255,13 +255,13 @@ void MemoryProfile(long& vm_usage, long& resident_set) {
   std::ifstream ifs("/proc/self/stat", std::ios_base::in);
   std::string mem_in;
   getline(ifs, mem_in);
-  if(mem_in != "") {
+  if (mem_in != "") {
     vector<string> mem_str = ng::split(mem_in, ' ');
     vsize = std::stol(mem_str[22]);
     rss = std::stol(mem_str[23]);
 
     long page_size_kb = sysconf(_SC_PAGE_SIZE) /
-                      1024;  // in case x86-64 is configured to use 2MB pages
+                        1024;  // in case x86-64 is configured to use 2MB pages
     vm_usage = vsize / 1024;   // unit kb
     resident_set = rss * page_size_kb;
   }


### PR DESCRIPTION
/proc/self/stat does not exist on Mac because of which mem_str
was an empty string being fed to stol resulting in the
invalid_argument error
