### PR TITLE
avijit/Add diagnostics for debugging AllReduce ops

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -432,7 +432,7 @@ def main():
     #-------------------------------
 
     # Component versions
-    ngraph_version = "d3453447883fe48e63126316d5da72fcbd47dded"
+    ngraph_version = "avijit/add_diag_4_distributed_debugging"
     tf_version = "v1.12.0"
 
     # Default directories

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -446,8 +446,8 @@ static Status TranslateAllreduceOp(
   shared_ptr<ng::Node> ng_input;
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_input));
 
-  //Get the corresponding TF op to ng_input
-  //Set name of the ng input node same as TF op
+  // Get the corresponding TF op to ng_input
+  // Set name of the ng input node same as TF op
   Node* tf_input;
   TF_RETURN_IF_ERROR(op->input_node(0, &tf_input));
   ng_input->set_friendly_name(tf_input->name());
@@ -4185,18 +4185,17 @@ Status Builder::TranslateGraph(
   vector<const Node*> tf_ret_vals;
   vector<const Node*> tf_ops;
 
-  #if defined(NGRAPH_DISTRIBUTED)
-    int flag = 0;
-    int mpi_rank = -1;
-    bool mpi_initialized = false;
-    MPI_Initialized(&flag);
-    if (!flag)
-    {
-        MPI_Init(NULL, NULL);
-        mpi_initialized = true;
-    }
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-  #endif
+#if defined(NGRAPH_DISTRIBUTED)
+  int flag = 0;
+  int mpi_rank = -1;
+  bool mpi_initialized = false;
+  MPI_Initialized(&flag);
+  if (!flag) {
+    MPI_Init(NULL, NULL);
+    mpi_initialized = true;
+  }
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+#endif
 
   for (const auto n : ordered) {
     if (n->IsSink() || n->IsSource()) {
@@ -4215,25 +4214,23 @@ Status Builder::TranslateGraph(
       tf_ret_vals.push_back(n);
     } else {
       tf_ops.push_back(n);
-      #if defined(NGRAPH_DISTRIBUTED)
-      if ( n->type_string() == "HorovodAllreduce") {
+#if defined(NGRAPH_DISTRIBUTED)
+      if (n->type_string() == "HorovodAllreduce") {
         NGRAPH_VLOG(1) << "[NGRAPH_TF RANK: " << mpi_rank << "]: " << n->name();
       }
-      #endif
-
+#endif
     }
   }
 
-  #if defined(NGRAPH_DISTRIBUTED)
-    if( mpi_initialized ){
-      int flag = 0;
-      MPI_Initialized(&flag);
-      if (flag){
-        MPI_Finalize();
-      }
+#if defined(NGRAPH_DISTRIBUTED)
+  if (mpi_initialized) {
+    int flag = 0;
+    MPI_Initialized(&flag);
+    if (flag) {
+      MPI_Finalize();
     }
-  #endif
-
+  }
+#endif
 
   //
   // The op map holds a mapping from TensorFlow op names (strings) to

--- a/src/ngraph_builder.cc
+++ b/src/ngraph_builder.cc
@@ -33,6 +33,10 @@
 #include "tensorflow/core/graph/edgeset.h"
 #include "tensorflow/core/lib/core/errors.h"
 
+#if defined(NGRAPH_DISTRIBUTED)
+#include <mpi.h>
+#endif
+
 using namespace std;
 namespace ng = ngraph;
 
@@ -442,7 +446,16 @@ static Status TranslateAllreduceOp(
   shared_ptr<ng::Node> ng_input;
   TF_RETURN_IF_ERROR(GetInputNodes(ng_op_map, op, &ng_input));
 
-  SaveNgOp(ng_op_map, op->name(), make_shared<ng::op::AllReduce>(ng_input));
+  //Get the corresponding TF op to ng_input
+  //Set name of the ng input node same as TF op
+  Node* tf_input;
+  TF_RETURN_IF_ERROR(op->input_node(0, &tf_input));
+  ng_input->set_friendly_name(tf_input->name());
+
+  auto ng_all_reduce = make_shared<ng::op::AllReduce>(ng_input);
+  ng_all_reduce->set_friendly_name(op->name());
+  SaveNgOp(ng_op_map, op->name(), ng_all_reduce);
+
   return Status::OK();
 }
 
@@ -4172,6 +4185,19 @@ Status Builder::TranslateGraph(
   vector<const Node*> tf_ret_vals;
   vector<const Node*> tf_ops;
 
+  #if defined(NGRAPH_DISTRIBUTED)
+    int flag = 0;
+    int mpi_rank = -1;
+    bool mpi_initialized = false;
+    MPI_Initialized(&flag);
+    if (!flag)
+    {
+        MPI_Init(NULL, NULL);
+        mpi_initialized = true;
+    }
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+  #endif
+
   for (const auto n : ordered) {
     if (n->IsSink() || n->IsSource()) {
       continue;
@@ -4189,8 +4215,25 @@ Status Builder::TranslateGraph(
       tf_ret_vals.push_back(n);
     } else {
       tf_ops.push_back(n);
+      #if defined(NGRAPH_DISTRIBUTED)
+      if ( n->type_string() == "HorovodAllreduce") {
+        NGRAPH_VLOG(1) << "[NGRAPH_TF RANK: " << mpi_rank << "]: " << n->name();
+      }
+      #endif
+
     }
   }
+
+  #if defined(NGRAPH_DISTRIBUTED)
+    if( mpi_initialized ){
+      int flag = 0;
+      MPI_Initialized(&flag);
+      if (flag){
+        MPI_Finalize();
+      }
+    }
+  #endif
+
 
   //
   // The op map holds a mapping from TensorFlow op names (strings) to


### PR DESCRIPTION
* Setting the `friendly_name` of the nGraph AllReduce op to the TensorFlow op name for easy correlation in the debug logs
* Enabled printing the order of TensorFlow Horovod ops at the TensorFlow level to help debug out of order execution
