### PR TITLE
Rel 0.12.0-rc1 prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ if (NOT USE_PRE_BUILT_NGRAPH)
     ExternalProject_Add(
         ext_ngraph
         GIT_REPOSITORY https://github.com/NervanaSystems/ngraph
-        GIT_TAG v0.15.1-rc.2
+        GIT_TAG v0.16.0-rc.0
         CMAKE_ARGS 
             -DNGRAPH_DISTRIBUTED_ENABLE=${NGRAPH_DISTRIBUTED_ENABLE}
             -DNGRAPH_INSTALL_PREFIX=${NGRAPH_ARTIFACTS_DIR}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ a variety of nGraph-enabled backends: CPU, GPU, and custom silicon like the
         virtualenv --system-site-packages -p /usr/bin/python2 your_virtualenv  
         source your_virtualenv/bin/activate # bash, sh, ksh, or zsh
     
-2. Install TensorFlow v1.12.0:
+2. Install TensorFlow v1.13.1:
 
         pip install -U tensorflow
 
@@ -41,10 +41,10 @@ a variety of nGraph-enabled backends: CPU, GPU, and custom silicon like the
 
 This will produce something like this:
 
-        TensorFlow version:  1.12.0
-        nGraph bridge version: b'0.11.0'
-        nGraph version used for this build: b'0.14.0+56a54ca'
-        TensorFlow version used for this build: v1.12.0-0-ga6d8ffae09
+        TensorFlow version:  1.13.1
+        nGraph bridge version: b'0.12.0-rc1'
+        nGraph version used for this build: b'0.21.0-rc.0+b638705'
+        TensorFlow version used for this build: v1.13.1-0-g6612da8951
 
 Next you can try out the TensorFlow models by adding one line to your existing 
 TensorFlow model scripts and running them the usual way:
@@ -63,11 +63,11 @@ bridge using the TensorFlow source tree as follows:
 The installation prerequisites are the same as described in the TensorFlow 
 [prepare environment] for linux.
 
-1. TensorFlow uses a build system called "bazel". These instructions were tested with [bazel version 0.16.0]. 
+1. TensorFlow uses a build system called "bazel". These instructions were tested with [bazel version 0.21.0]. 
 
-        wget https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel-0.16.0-installer-linux-x86_64.sh      
-        chmod +x bazel-0.16.0-installer-linux-x86_64.sh
-        ./bazel-0.16.0-installer-linux-x86_64.sh --user
+        wget https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh      
+        chmod +x bazel-0.21.0-installer-linux-x86_64.sh
+        ./bazel-0.21.0-installer-linux-x86_64.sh --user
 
 2. Add and source the ``bin`` path to your ``~/.bashrc`` file in order to be 
    able to call bazel from the user's installation we set up:
@@ -84,7 +84,7 @@ The installation prerequisites are the same as described in the TensorFlow
 
         git clone https://github.com/NervanaSystems/ngraph-tf.git
         cd ngraph-tf
-        git checkout v0.11.0
+        git checkout v0.12.0-rc1
 
    
 2. Next run the following Python script to build TensorFlow, nGraph and the bridge. Please use Python 3.5:
@@ -114,70 +114,6 @@ Once the build and installation steps are complete, you can start using TensorFl
 with nGraph backends. 
 
 Please add the following line to enable nGraph: `import ngraph_bridge`
-
-## Option 3: Using the upstreamed version
-
-nGraph is updated in the TensorFlow source tree using pull requests periodically. 
-
-In order to build that version of nGraph, follow the steps below, which involves building TensorFlow from source with certain settings.
-
-1. Install bazel using the same instructions outlined in option 2, step 1 above.
-
-2. Create a virtual environment using the instructions outlined in option 1, step 1 above.
-
-3. Get tensorflow v1.12.0
-
-        git clone https://github.com/tensorflow/tensorflow.git
-        cd tensorflow
-        git checkout v1.12.0
-
-Note: To get the latest version of nGraph, use the tip of `master` branch of TensorFlow. The exact version of `bazel` changes for a specific version of TensorFlow. Please consult the build instructions from TensorFlow web site for specific bazel requirements.
-
-4. Now run `./configure` and choose `no` for the following when prompted to build TensorFlow.
-
-    XLA support:
-
-        Do you wish to build TensorFlow with XLA JIT support? [Y/n]: n
-        No XLA JIT support will be enabled for TensorFlow.
-
-    CUDA support:
-    
-        Do you wish to build TensorFlow with CUDA support? [y/N]: N
-        No CUDA support will be enabled for TensorFlow.
-    
-    :warning: Note that if you are running TensorFlow on a Skylake family processor then select
-    `-march=broadwell` when prompted to specify the optimization flags:
-    
-        Please specify optimization flags to use during compilation 
-        when bazel option "--config=opt" is specified 
-        [Default is -march=native]: -march=broadwell
-    
-    This is due to an issue in TensorFlow tracked here: 
-    https://github.com/tensorflow/tensorflow/issues/17273
-
-5. Prepare the pip package
-
-        bazel build --config=opt --config=ngraph //tensorflow/tools/pip_package:build_pip_package 
-        bazel-bin/tensorflow/tools/pip_package/build_pip_package ./
-
-Note: The specific questions for the `configure` step and the build command mentioned above changes for different versions of TensorFlow. 
-
-6. Once the pip package is built, install using
-
-        pip install -U ./tensorflow-1.*whl
-
-For this final option, there is **no need to separately build `ngraph-tf` or to 
-use `pip` to install the nGraph module**. With this configuration, your TensorFlow model scripts will work without any changes, ie, you do not need to add `import ngraph_bridge`, like option 1 and 2. 
-
-Note: The version that is available in the upstreamed version of TensorFlow usually
-lags the features and bug fixes available in the `master` branch of this repository.
-
-You can run a few of your own DL models to validate the end-to-end 
-functionality. Also, you can use the `ngraph-tf/examples` directory and try to 
-run the following model: 
-
-        cd examples
-        python3 keras_sample.py 
 
 ## Using OS X 
 
@@ -223,7 +159,7 @@ See the full documentation here:  <http://ngraph.nervanasys.com/docs/latest>
 [DSO]:http://csweb.cs.wfu.edu/~torgerse/Kokua/More_SGI/007-2360-010/sgi_html/ch03.html
 [Github issues]: https://github.com/NervanaSystems/ngraph-tf/issues
 [pull request]: https://github.com/NervanaSystems/ngraph-tf/pulls
-[bazel version 0.16.0]: https://github.com/bazelbuild/bazel/releases/tag/0.16.0
+[bazel version 0.21.0]: https://github.com/bazelbuild/bazel/releases/tag/0.21.0
 [prepare environment]: https://www.tensorflow.org/install/install_sources#prepare_environment_for_linux
 [diagnostics]:diagnostics/README.md
 [ops]:http://ngraph.nervanasys.com/docs/latest/ops/index.html

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -44,7 +44,7 @@ def command_executor(cmd, verbose=False, msg=None, stdout=None):
         raise Exception("Error running command: " + cmd)
 
 
-def build_ngraph(src_location, cmake_flags, verbose):
+def build_ngraph(build_dir, src_location, cmake_flags, verbose):
     pwd = os.getcwd()
 
     src_location = os.path.abspath(src_location)
@@ -53,7 +53,7 @@ def build_ngraph(src_location, cmake_flags, verbose):
     os.chdir(src_location)
 
     # mkdir build directory
-    path = 'build'
+    path =  build_dir
     try:
         os.makedirs(path)
     except OSError as exc:  # Python >2.5
@@ -61,7 +61,7 @@ def build_ngraph(src_location, cmake_flags, verbose):
             pass
 
     # Run cmake
-    os.chdir('build')
+    os.chdir(build_dir)
 
     cmake_cmd = ["cmake"]
     cmake_cmd.extend(cmake_flags)
@@ -278,7 +278,7 @@ def install_tensorflow(venv_dir, artifacts_dir):
     return str(cxx_abi)
 
 
-def build_ngraph_tf(artifacts_location, ngtf_src_loc, venv_dir, cmake_flags,
+def build_ngraph_tf(build_dir, artifacts_location, ngtf_src_loc, venv_dir, cmake_flags,
                     verbose):
     pwd = os.getcwd()
 
@@ -296,7 +296,7 @@ def build_ngraph_tf(artifacts_location, ngtf_src_loc, venv_dir, cmake_flags,
     os.chdir(ngtf_src_loc)
 
     # mkdir build directory
-    path = 'build'
+    path =  build_dir
     try:
         os.makedirs(path)
     except OSError as exc:  # Python >2.5
@@ -304,7 +304,7 @@ def build_ngraph_tf(artifacts_location, ngtf_src_loc, venv_dir, cmake_flags,
             pass
 
     # Run cmake
-    os.chdir('build')
+    os.chdir(path)
     cmake_cmd = ["cmake"]
     cmake_cmd.extend(cmake_flags)
     cmake_cmd.extend([ngtf_src_loc])
@@ -408,8 +408,8 @@ def main():
     parser.add_argument(
         '--use_prebuilt_binaries',
         help=
-        "Skip building nGraph and TensorFlow. Rather use \"build\" directory.\n"
-        + "The following directory structure is assumed:\n" + "build\n" +
+        "Skip building nGraph and TensorFlow. Rather use \"build_cmake\" directory.\n"
+        + "The following directory structure is assumed:\n" + "build_cmake\n" +
         "  |\n" + "   -- artifacts\n" + "  |   |\n" +
         "  |   |-- bin (contains binaries from nGraph build)\n" +
         "  |   |-- include (contains include files from nGraph build)\n" +
@@ -440,11 +440,11 @@ def main():
     #-------------------------------
 
     # Component versions
-    ngraph_version = "v0.15.1-rc.2"
-    tf_version = "v1.12.0"
+    ngraph_version = "v0.16.0-rc.0"
+    tf_version = "v1.13.1"
 
     # Default directories
-    build_dir = 'build'
+    build_dir = 'build_cmake'
 
     # Override the pre-built location is specified
     use_prebuilt_binaries = False
@@ -536,7 +536,7 @@ def main():
         else:
             ngraph_cmake_flags.extend(["-DNGRAPH_GPU_ENABLE=NO"])
 
-        build_ngraph("./ngraph", ngraph_cmake_flags, verbosity)
+        build_ngraph(build_dir, "./ngraph", ngraph_cmake_flags, verbosity)
 
     # Next build CMAKE options for the bridge
     tf_src_dir = os.path.abspath("tensorflow")
@@ -559,7 +559,7 @@ def main():
         ngraph_tf_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=FALSE"])
 
     # Now build the bridge
-    ng_tf_whl = build_ngraph_tf(artifacts_location, "../", venv_dir,
+    ng_tf_whl = build_ngraph_tf(build_dir, artifacts_location, "../", venv_dir,
                                 ngraph_tf_cmake_flags, verbosity)
 
     print("SUCCESSFULLY generated wheel: %s" % ng_tf_whl)

--- a/python/setup.in.py
+++ b/python/setup.in.py
@@ -39,7 +39,7 @@ with open(@README_DOC@, "r") as fh:
 
 setup( 
     name='ngraph_tensorflow_bridge',
-    version='0.12.0-rc0',
+    version='0.12.0rc1',
     description='Intel nGraph compiler and runtime for TensorFlow',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/version.cc
+++ b/src/version.cc
@@ -30,7 +30,7 @@
 // candidate such as v0.7.0-rc0
 // The code in master will always have the last released version number
 // with a suffix of '-master'
-#define NG_TF_VERSION_SUFFIX "-rc0"
+#define NG_TF_VERSION_SUFFIX "-rc1"
 
 #define VERSION_STR_HELPER(x) #x
 #define VERSION_STR(x) VERSION_STR_HELPER(x)

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
@@ -75,8 +75,8 @@ RUN pip install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 #
 # This bazel version works with current TF
-RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
+RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.21.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py3
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py3
@@ -79,8 +79,8 @@ RUN pip3 install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 #
 # This bazel version works with current TF
-RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
+RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.21.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1604_gcc48_py35
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1604_gcc48_py35
@@ -84,8 +84,8 @@ RUN pip3 install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 #
 # This bazel version works with current TF
-RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
+RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.21.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1604_py35
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1604_py35
@@ -66,8 +66,8 @@ RUN pip3 install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 #
 # This bazel version works with current TF
-RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
+RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.21.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1804_py36
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_ubuntu1804_py36
@@ -63,8 +63,8 @@ RUN pip3 install --upgrade pytest
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 
 # This bazel version works with current TF
-RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.16.0/bazel_0.16.0-linux-x86_64.deb
-RUN dpkg -i bazel_0.16.0-linux-x86_64.deb || true
+RUN wget --no-verbose -c https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel_0.21.0-linux-x86_64.deb
+RUN dpkg -i bazel_0.21.0-linux-x86_64.deb || true
 
 # Copy in the run-as-user.sh script
 # This will allow the builds, which are done in a mounted directory, to

--- a/test_ngtf.py
+++ b/test_ngtf.py
@@ -233,10 +233,10 @@ def run_bazel_build_test(venv_dir, build_dir):
     command_executor(['bash', 'configure_bazel.sh'])
 
     # Build the bridge
-    command_executor(['bazel', 'build', 'libngraph_bridge.so'])
+    command_executor(['bazel', 'build', '--incompatible_remove_native_http_archive=false', 'libngraph_bridge.so'])
     
     # Build the backend
-    command_executor(['bazel', 'build', '@ngraph//:libinterpreter_backend.so'])
+    command_executor(['bazel', 'build', '--incompatible_remove_native_http_archive=false', '@ngraph//:libinterpreter_backend.so'])
 
     # Return to the original directory
     os.chdir(root_pwd)

--- a/test_ngtf.py
+++ b/test_ngtf.py
@@ -268,8 +268,8 @@ def main():
     root_pwd = os.getcwd()
 
     # Constants
-    build_dir = 'build'
-    venv_dir = 'build/venv-tf-py3'
+    build_dir = 'build_cmake'
+    venv_dir = 'build_cmake/venv-tf-py3'
 
     if (platform.system() != 'Darwin'):
         # Run the bazel based buil


### PR DESCRIPTION
* Changed the name of the build directory to `build_cmake` as the name `build` conflicts with the bazel `BUILD` file for the MacOS.
* Upgraded to TensorFlow 1.13.1 release
* Removed the build option 3 as it's not maintained. The new home for nGraph bridge will be `tensorflow/ngraph_bridge` after the current release.