### PR TITLE
Avijit/release 0.12.0 prep.02

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ endif(APPLE)
 option(USE_PRE_BUILT_NGRAPH "Use pre-built nGraph located in NGRAPH_ARTIFACTS_DIR" FALSE)
 option(NGRAPH_ARTIFACTS_DIR "Where would nGraph be installed after build" FALSE)
 option(UNIT_TEST_ENABLE "Control the building of unit tests" FALSE)
-option(UNIT_TEST_TF_CC_DIR "Location where TensorFlow CC library is located" )
+option(UNIT_TEST_TF_CC_DIR "Location where TensorFlow CC library is located" FALSE)
 option(NGRAPH_DISTRIBUTED_ENABLE "Add distributed mode to the CPU backend" FALSE)
 
 
@@ -182,6 +182,7 @@ else()
     set(NGRAPH_ARTIFACTS_DIR ${CMAKE_CURRENT_BINARY_DIR}/ngraph/ngraph_dist)
 endif()
 
+message(STATUS "UNIT_TEST_TF_CC_DIR:        ${TF_PRE_BUILT_LOCATION}")
 if(UNIT_TEST_TF_CC_DIR)
     # Check if the path specified is ABSOLUTE or RELATVE
     if (NOT IS_ABSOLUTE ${UNIT_TEST_TF_CC_DIR})
@@ -219,7 +220,6 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=${NGRAPH_TARGET_ARCH}")
 
 message(STATUS "UNIT_TEST_ENABLE:           ${UNIT_TEST_ENABLE}")
-message(STATUS "UNIT_TEST_TF_CC_DIR:        ${TF_PRE_BUILT_LOCATION}")
 
 message(STATUS "NGRAPH_ARTIFACTS_DIR:       ${NGRAPH_ARTIFACTS_DIR}")
 message(STATUS "USE_PRE_BUILT_NGRAPH:       ${USE_PRE_BUILT_NGRAPH}")

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -44,6 +44,7 @@ cc_binary(
         "src/ngraph_rewrite_for_tracking.h",
         "src/ngraph_rewrite_pass.cc",
         "src/ngraph_timer.h",
+        "src/ngraph_timer.cc",
         "src/ngraph_tracked_variable.cc",
         "src/ngraph_utils.cc",
         "src/ngraph_utils.h",

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -15,26 +15,27 @@
 # ==============================================================================
 
 workspace(name = "ngraph_bridge")
-load("//tf_configure:tf_configure.bzl", "tf_configure")
+load("@//tf_configure:tf_configure.bzl", "tf_configure")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 tf_configure(
     name = "local_config_tf",
 )
 
-new_http_archive(
+http_archive(
     name = "ngraph",
-    build_file = "bazel/ngraph.BUILD",
-    sha256 = "013868077223a7a2ca10d8604e1b743e64fa26abda2b97694922696ab3e3d3eb",
-    strip_prefix = "ngraph-0.15.0-rc.1",
+    build_file = "//:bazel/ngraph.BUILD",
+    sha256 = "02b07294ff3403c461acf7b1a282061560972daa8c5fb67a4f15722dd80a2922",
+    strip_prefix = "ngraph-0.16.0-rc.0",
     urls = [
-        "https://mirror.bazel.build/github.com/NervanaSystems/ngraph/archive/v0.15.0-rc.1.tar.gz",
-        "https://github.com/NervanaSystems/ngraph/archive/v0.15.0-rc.1.tar.gz",
+        "https://mirror.bazel.build/github.com/NervanaSystems/ngraph/archive/v0.16.0-rc.0.tar.gz",
+        "https://github.com/NervanaSystems/ngraph/archive/v0.16.0-rc.0.tar.gz",
     ],
 )
 
-new_http_archive(
+http_archive(
     name = "nlohmann_json_lib",
-    build_file = "bazel/nlohmann_json.BUILD",
+    build_file = "//:bazel/nlohmann_json.BUILD",
     sha256 = "e0b1fc6cc6ca05706cce99118a87aca5248bd9db3113e703023d23f044995c1d",
     strip_prefix = "json-3.5.0",
     urls = [

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -524,7 +524,6 @@ def main():
         ngraph_cmake_flags = [
             "-DNGRAPH_INSTALL_PREFIX=" + artifacts_location,
             "-DNGRAPH_USE_CXX_ABI=" + cxx_abi,
-            "-DNGRAPH_UNIT_TEST_ENABLE=YES",
             "-DNGRAPH_DEX_ONLY=TRUE",
             "-DNGRAPH_DEBUG_ENABLE=NO",
             "-DNGRAPH_TARGET_ARCH=" + target_arch,
@@ -547,6 +546,11 @@ def main():
             ngraph_cmake_flags.extend(["-DNGRAPH_GPU_ENABLE=YES"])
         else:
             ngraph_cmake_flags.extend(["-DNGRAPH_GPU_ENABLE=NO"])
+
+        if not arguments.use_prebuilt_tensorflow:
+            ngraph_cmake_flags.extend(["-DNGRAPH_UNIT_TEST_ENABLE=YES"])
+        else:
+            ngraph_cmake_flags.extend(["-DNGRAPH_UNIT_TEST_ENABLE=NO"])
 
         build_ngraph(build_dir, "./ngraph", ngraph_cmake_flags, verbosity)
 

--- a/configure_bazel.sh
+++ b/configure_bazel.sh
@@ -25,7 +25,7 @@ rm -f .bazelrc
 if python -c "import tensorflow" &> /dev/null; then
     echo 'using installed tensorflow'
 else
-    pip install tensorflow==1.12.0
+    pip install tensorflow==1.13.1
     pip install tensorflow_estimator
 fi
 

--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -616,18 +616,33 @@ class NGraphEncapsulateOp : public OpKernel {
 
     // Copy value to host if backend is not CPU
     Event event_copy_output("Output - copy back", name().c_str());
-
     Timer copy_output_tensors_to_host;
 
     try {
       if (m_op_backend_name != "CPU") {
-        for (size_t i = 0; i < output_caches.size(); ++i) {
+        size_t output_tensor_count = output_caches.size();
+        std::vector<std::unique_ptr<Event>> events;
+        for (size_t i = 0; i < output_tensor_count; ++i) {
           void* dst_ptr;
           std::shared_ptr<ng::runtime::Tensor> dst_ng_tensor;
           std::tie(dst_ptr, dst_ng_tensor) = output_caches[i];
           auto ng_element_type = dst_ng_tensor->get_element_type();
-          dst_ng_tensor->read(dst_ptr, 0, dst_ng_tensor->get_element_count() *
-                                              ng_element_type.size());
+          std::unique_ptr<Event> event_copy_output_next(
+              new Event(("Output_" + std::to_string(i) + "_" +
+                         std::to_string(dst_ng_tensor->get_element_count() *
+                                        ng_element_type.size()))
+                            .c_str(),
+                        name().c_str()));
+          dst_ng_tensor->read(
+              dst_ptr, 0,
+              dst_ng_tensor->get_element_count() * ng_element_type.size());
+          event_copy_output_next->Stop();
+          events.push_back(std::move(event_copy_output_next));
+        }
+
+        // Now writethe events back
+        for (auto& next : events) {
+          Event::WriteTrace(*next.get());
         }
       }
     } catch (const std::exception& exp) {

--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -640,7 +640,7 @@ class NGraphEncapsulateOp : public OpKernel {
           events.push_back(std::move(event_copy_output_next));
         }
 
-        // Now writethe events back
+        // Now write the events back
         for (auto& next : events) {
           Event::WriteTrace(*next.get());
         }

--- a/src/ngraph_encapsulate_op.cc
+++ b/src/ngraph_encapsulate_op.cc
@@ -634,9 +634,8 @@ class NGraphEncapsulateOp : public OpKernel {
                                         ng_element_type.size()))
                             .c_str(),
                         name().c_str()));
-          dst_ng_tensor->read(
-              dst_ptr, 0,
-              dst_ng_tensor->get_element_count() * ng_element_type.size());
+          dst_ng_tensor->read(dst_ptr, 0, dst_ng_tensor->get_element_count() *
+                                              ng_element_type.size());
           event_copy_output_next->Stop();
           events.push_back(std::move(event_copy_output_next));
         }

--- a/src/ngraph_timer.h
+++ b/src/ngraph_timer.h
@@ -106,8 +106,8 @@ class Event {
   std::string m_name;
   std::string m_category;
   std::string m_args;
-  int m_pid;
-  int m_tid;
+  int m_pid{0};
+  int m_tid{0};
   static std::mutex s_file_mutex;
   static std::ofstream s_event_log;
 };

--- a/test_ngtf.py
+++ b/test_ngtf.py
@@ -233,10 +233,10 @@ def run_bazel_build_test(venv_dir, build_dir):
     command_executor(['bash', 'configure_bazel.sh'])
 
     # Build the bridge
-    command_executor(['bazel', 'build', '--incompatible_remove_native_http_archive=false', 'libngraph_bridge.so'])
+    command_executor(['bazel', 'build', 'libngraph_bridge.so'])
     
     # Build the backend
-    command_executor(['bazel', 'build', '--incompatible_remove_native_http_archive=false', '@ngraph//:libinterpreter_backend.so'])
+    command_executor(['bazel', 'build', '@ngraph//:libinterpreter_backend.so'])
 
     # Return to the original directory
     os.chdir(root_pwd)


### PR DESCRIPTION
* Fixed bazel build (upgraded to new API that uses http_archive)
* Added the option to use pre-installed TensorFlow for building nGraph
* Added option to be able to build PlaidML backend
* Removed the option `use_prebuilt_binaries` from build_ngtf.py
* Added event tracing for output copy in NGraphEncapsulate Op.