### PR TITLE
junit-wrap.sh exits with status of test command that it wraps

### DIFF
--- a/test/ci/junit-wrap.sh
+++ b/test/ci/junit-wrap.sh
@@ -117,7 +117,6 @@ then
     echo
     ((NUM_PASSED += 1))
 else
-    local TEST_EXIT_CODE=${?}
     ((JUNIT_TESTS += 1))
     ((JUNIT_FAIL += 1))
     ((JUNIT_SUITE_TESTS += 1))
@@ -141,3 +140,7 @@ echo "<testsuites tests=\"${JUNIT_TESTS}\" failures=\"${JUNIT_FAIL}\" disabled=\
 echo "${JUNIT_XML}" >> "${JUNIT_WRAP_FILE}"
 echo '</testsuites>' >> "${JUNIT_WRAP_FILE}"
 echo "JUnit XML output written to ${JUNIT_WRAP_FILE}"
+
+# Exit the junit-wrap script with the exact exit code of the unit-test process,
+# so that any upstream script properly triggers on the exit code
+exit ${STATUS}


### PR DESCRIPTION
Addition to junit-wrap.sh to exit with the exit status of the test command run (as long as junit-wrap does not fail).  This is safer in that it will insure that the wrapper will trigger any mechanism in the calling script that fires on non-zero exits.  Note that Jenkins should have properly caught any failing xunit tests via the test results import, but having the junit-wrapper also report the exit status of the test script is a good double-check.