### PR TITLE
Update MacOS python2 builds to use latest tensorflow version (1.13.1)

### DIFF
--- a/test/ci/macos/run-ngraph-tf-mac-build.sh
+++ b/test/ci/macos/run-ngraph-tf-mac-build.sh
@@ -223,7 +223,7 @@ if [ -z "${tf_dir}" ] ; then
     # If installing into the OS, use:
     # sudo --preserve-env --set-home pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${WHEEL_FILE}"
     # Here we are installing into a virtual environment, so DO NOT USE SUDO!!!
-    pip install -U tensorflow
+    pip install -U tensorflow==1.13.1
     set +x
 
 else 

--- a/test/ci/macos/run-ngraph-tf-mac-build.sh
+++ b/test/ci/macos/run-ngraph-tf-mac-build.sh
@@ -223,7 +223,7 @@ if [ -z "${tf_dir}" ] ; then
     # If installing into the OS, use:
     # sudo --preserve-env --set-home pip install --ignore-installed ${PIP_INSTALL_EXTRA_ARGS:-} "${WHEEL_FILE}"
     # Here we are installing into a virtual environment, so DO NOT USE SUDO!!!
-    pip install -U tensorflow==1.12.0
+    pip install -U tensorflow
     set +x
 
 else 


### PR DESCRIPTION
This update only changes the python2 builds for MacOS.  It updates the builds to use latest tensorflow (i.e. "pip install tensorflow"), since ngraph-bridge now supports the latest TF version 1.13.1.