### PR TITLE
Add support for CentOS 7.6 builds in docker containers

### DIFF
--- a/test/ci/docker/docker-scripts/run-build-test-ngtf.sh
+++ b/test/ci/docker/docker-scripts/run-build-test-ngtf.sh
@@ -1,5 +1,4 @@
-
-        #!  /bin/bash
+#!  /bin/bash
 
 # ==============================================================================
 #  Copyright 2018 Intel Corporation
@@ -112,37 +111,6 @@ pip --version
 echo ' '
 echo 'Ubuntu version is:'
 cat /etc/os-release
-
-xtime="$(date)"
-echo  ' '
-echo  "===== Setting Up Virtual Environment for Code-Format Check at ${xtime} ====="
-echo  ' '
-
-# Make sure the bash shell prompt variables are set, as virtualenv crashes
-# if PS2 is not set.
-PS1='prompt> '
-PS2='prompt-more> '
-virtualenv --system-site-packages -p /usr/bin/python2 "${venv_dir}"
-source "${venv_dir}/bin/activate"
-
-# yapf and futures are needed for code-format checks (ngraph-tf PR#211)
-pip install yapf==0.24.0
-pip install futures
-
-xtime="$(date)"
-echo  ' '
-echo  "===== Starting nGraph TensorFlow Bridge Source Code Format Check at ${xtime} ====="
-echo  ' '
-
-cd "${bridge_dir}"
-maint/check-code-format.sh
-
-xtime="$(date)"
-echo  ' '
-echo  "===== Deactivating Virtual Environment at ${xtime} ====="
-echo  ' '
-
-deactivate
 
 xtime="$(date)"
 echo  ' '

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_centos76_py34
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph_tf.build_ngtf_centos76_py34
@@ -1,0 +1,86 @@
+# ==============================================================================
+#  Copyright 2019 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ==============================================================================
+
+# Environment to build and unit-test ngraph-bridge on CentOS 7.6
+
+FROM centos:7.6.1810
+
+# Python environment is python 3.4, which is preferred Py3 on CentOS 7.6
+# git is needed to clone tensorflow repository
+# unzip and wget are needed for installing bazel
+# sudo is required for installing the TF wheel into /usr/local/...
+# zlib-dev and bash-completion are required by bazel install
+# zip is needed to run TensorFlow tests
+# wget is used below to get the bazel distro
+# curl and mlocate are needed by Tensorflow's configure command
+# "which" is needed to unpack bazel
+# gcc, gcc-c++, and cmake3 are needed to build ngraph
+
+RUN yum groupinstall -y "Development Tools" && \
+    yum -y --enablerepo=extras install epel-release && \
+    yum -y install \
+    python34 python34-devel python34-setuptools python34-pip \
+    java-1.8.0-openjdk \
+    git \
+    unzip \
+    sudo \
+    zlib-dev \
+    zip \
+    wget \
+    mlocate curl \
+    which \
+    gcc gcc-c++ \
+    cmake3
+
+# We need to make cmake3, required by ngraph builds, to be runnable as the
+# default "cmake" command
+RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# Print versions, for reference
+RUN cmake --version
+RUN make --version
+RUN gcc --version
+RUN c++ --version
+
+# The "locate" command uses a prepopulated index.  If this index is not built,
+# then "locate" will find absolutely nothing.  In Tensorflow's configure,
+# this manifests itself as a silent failure of the configure script to run to
+# completion.  Therefore, updatedb MUST BE RUN to provide an index for "locate".
+RUN updatedb
+
+# The pip-upgrade for pip, setuptools, and virtualenv is to avoid a nasty
+#   bug in setuptools: "_NamespacePath object has no attribute sort"
+RUN pip3 install --upgrade pip setuptools virtualenv==16.1.0
+
+# We include pytest so the Docker image can be used for daily validation
+RUN pip3 install --upgrade pytest
+
+# This bazel version works with current TF
+# Install the most recent bazel release.
+ARG BAZEL_VERSION=0.21.0
+RUN mkdir /bazel && \
+    cd /bazel && \
+    wget --quiet https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh && \
+    wget --quiet https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE; \
+    chmod +x bazel-*.sh && \
+    ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh && \
+    cd / && \
+    rm -f /bazel/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+# Copy in the run-as-user.sh script
+# This will allow the builds, which are done in a mounted directory, to
+# be run as the user who runs "docker run".  This then allows the mounted
+# directory to be properly deleted by the user later (e.g. by jenkins).
+WORKDIR /home


### PR DESCRIPTION
This PR adds the ability to run build_ngtf.py and test_ngtf.py on Centos 7.6 in a docker container.  Note that the _native_ Python 3 in CentOS 7.6 is python 3.4.

This PR also makes the following modifications to general docker scripts:
- run-as-user.sh has been modified to work on both RedHat-derived Linux distros as well as Debian/Ubuntu-derived distros (which were already supported)
- The code-format check has been removed from run-build-test-ngtf.sh, as it was previously broken out into a separate script

Successful testing: besides passing general CI pre-merge checks (see below), I also ran a full round of ngraph-tf-daily-build (four separate Linux builds), all which passed: https://aipg-rancher.intel.com/jenkins/algo/job/ngraph-tf-daily-build/590/