### PR TITLE
Avijit/add "include" directory to whl and few enhancements

### DIFF
--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -146,7 +146,7 @@ def main():
 
     # The cxx_abi flag is translated to _GLIBCXX_USE_CXX11_ABI
     # For gcc 4.8 - this flag is set to 0 and newer ones, this is set to 1
-    # The scpeific value is determined from the TensorFlow build
+    # The specific value is determined from the TensorFlow build
     # Normally the shipped TensorFlow is built with gcc 4.8 and thus this
     # flag is set to 0
     cxx_abi = "0"

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -17,10 +17,17 @@
 
 from tools.build_utils import *
 
+
 def main():
     '''
     Builds TensorFlow, ngraph, and ngraph-tf for python 3
     '''
+
+    # Component versions
+    ngraph_version = "v0.17.0-rc.1"
+    tf_version = "v1.13.1"
+
+    # Command line parser options
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
 
     parser.add_argument(
@@ -41,21 +48,18 @@ def main():
 
     parser.add_argument(
         '--build_gpu_backend',
-        help=
-        "nGraph backends will include nVidia GPU.\n"
+        help="nGraph backends will include nVidia GPU.\n"
         "Note: You need to have CUDA headers and libraries available on the build system.\n",
-        action="store_true"
-    )
+        action="store_true")
 
     parser.add_argument(
         '--build_plaidml_backend',
-        help=
-        "nGraph backends will include PlaidML bckend\n",
+        help="nGraph backends will include PlaidML bckend\n",
         action="store_true")
 
     parser.add_argument(
         '--use_prebuilt_tensorflow',
-        help="Skip building TensorFlow and use downloaded version.\n" + 
+        help="Skip building TensorFlow and use downloaded version.\n" +
         "Note that in this case C++ unit tests won't be build for nGrapg-TF bridge",
         action="store_true")
 
@@ -75,6 +79,20 @@ def main():
         type=str,
         help="Copy the artifacts to the given directory\n",
         action="store")
+
+    parser.add_argument(
+        '--ngraph_version',
+        type=str,
+        help="nGraph version to use (Default: " + ngraph_version + ")\n",
+        action="store")
+
+    parser.add_argument(
+        '--skip_tensorflow_build',
+        help="Use TensorFlow that's already installed" +
+        "(do not build or install) \n",
+        action="store_true")
+
+    # Done with the options. Now parse the commandline
     arguments = parser.parse_args()
 
     if (arguments.debug_build):
@@ -88,10 +106,6 @@ def main():
     #-------------------------------
     # Recipe
     #-------------------------------
-
-    # Component versions
-    ngraph_version = "v0.17.0-rc.1"
-    tf_version = "v1.13.1"
 
     # Default directories
     build_dir = 'build_cmake'
@@ -132,8 +146,8 @@ def main():
 
     # The cxx_abi flag is translated to _GLIBCXX_USE_CXX11_ABI
     # For gcc 4.8 - this flag is set to 0 and newer ones, this is set to 1
-    # The scpeific value is determined from the TensorFlow build 
-    # Normally the shipped TensorFlow is built with gcc 4.8 and thus this 
+    # The scpeific value is determined from the TensorFlow build
+    # Normally the shipped TensorFlow is built with gcc 4.8 and thus this
     # flag is set to 0
     cxx_abi = "0"
 
@@ -144,27 +158,40 @@ def main():
         import tensorflow as tf
         print('Version information:')
         print('TensorFlow version: ', tf.__version__)
-        print('C Compiler version used in building TensorFlow: ', tf.__compiler_version__)
+        print('C Compiler version used in building TensorFlow: ',
+              tf.__compiler_version__)
         cxx_abi = str(tf.__cxx11_abi_flag__)
     else:
-        print("Building TensorFlow")
-        # Download TensorFlow
-        download_repo("tensorflow",
-                      "https://github.com/tensorflow/tensorflow.git",
-                      tf_version)
+        if not arguments.skip_tensorflow_build:
+            print("Building TensorFlow")
+            # Download TensorFlow
+            download_repo("tensorflow",
+                        "https://github.com/tensorflow/tensorflow.git",
+                        tf_version)
 
-        # Build TensorFlow
-        build_tensorflow(venv_dir, "tensorflow", artifacts_location,
-                         target_arch, verbosity)
+            # Build TensorFlow
+            build_tensorflow(venv_dir, "tensorflow", artifacts_location,
+                            target_arch, verbosity)
 
-        # Install tensorflow
-        # Note that if gcc 4.8 is used for building TensorFlow this flag 
-        # will be 0 
-        cxx_abi = install_tensorflow(venv_dir, artifacts_location)
+            # Install tensorflow
+            # Note that if gcc 4.8 is used for building TensorFlow this flag
+            # will be 0
+            cxx_abi = install_tensorflow(venv_dir, artifacts_location)
+        else:
+            import tensorflow as tf
+            print('Version information:')
+            print('TensorFlow version: ', tf.__version__)
+            print('C Compiler version used in building TensorFlow: ',
+                tf.__compiler_version__)
+            cxx_abi = str(tf.__cxx11_abi_flag__)
 
     # Download nGraph
+    if arguments.ngraph_version:
+        ngraph_version = arguments.ngraph_version
+
+    print("nGraph Version: ", ngraph_version)
     download_repo("ngraph", "https://github.com/NervanaSystems/ngraph.git",
-                    ngraph_version)
+                  ngraph_version)
 
     # Now build nGraph
     ngraph_cmake_flags = [
@@ -183,9 +210,9 @@ def main():
     if arguments.debug_build:
         ngraph_cmake_flags.extend(["-DCMAKE_BUILD_TYPE=Debug"])
 
-    if (arguments.distributed_build=="OMPI"): 
+    if (arguments.distributed_build == "OMPI"):
         ngraph_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=OMPI"])
-    elif (arguments.distributed_build=="MLSL"): 
+    elif (arguments.distributed_build == "MLSL"):
         ngraph_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=MLSL"])
     else:
         ngraph_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=OFF"])
@@ -213,7 +240,8 @@ def main():
 
     ngraph_tf_cmake_flags = [
         "-DNGRAPH_TF_INSTALL_PREFIX=" + artifacts_location,
-        "-DUSE_PRE_BUILT_NGRAPH=ON", "-DNGRAPH_TARGET_ARCH=" + target_arch,
+        "-DUSE_PRE_BUILT_NGRAPH=ON",
+        "-DNGRAPH_TARGET_ARCH=" + target_arch,
         "-DNGRAPH_TUNE_ARCH=" + target_arch,
         "-DNGRAPH_ARTIFACTS_DIR=" + artifacts_location,
     ]
@@ -225,21 +253,27 @@ def main():
     else:
         ngraph_tf_cmake_flags.extend(["-DUNIT_TEST_ENABLE=ON"])
         ngraph_tf_cmake_flags.extend(["-DTF_SRC_DIR=" + tf_src_dir])
-        ngraph_tf_cmake_flags.extend(["-DUNIT_TEST_TF_CC_DIR=" + 
-            os.path.join(artifacts_location, "tensorflow")])
+        ngraph_tf_cmake_flags.extend([
+            "-DUNIT_TEST_TF_CC_DIR=" + os.path.join(artifacts_location,
+                                                    "tensorflow")
+        ])
 
-    if ((arguments.distributed_build=="OMPI") or (arguments.distributed_build=="MLSL")):
+    if ((arguments.distributed_build == "OMPI")
+            or (arguments.distributed_build == "MLSL")):
         ngraph_tf_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=TRUE"])
     else:
         ngraph_tf_cmake_flags.extend(["-DNGRAPH_DISTRIBUTED_ENABLE=FALSE"])
 
     if (arguments.use_grappler_optimizer):
-        ngraph_tf_cmake_flags.extend(["-DNGRAPH_TF_USE_GRAPPLER_OPTIMIZER=TRUE"])
+        ngraph_tf_cmake_flags.extend(
+            ["-DNGRAPH_TF_USE_GRAPPLER_OPTIMIZER=TRUE"])
     else:
-        ngraph_tf_cmake_flags.extend(["-DNGRAPH_TF_USE_GRAPPLER_OPTIMIZER=FALSE"])
+        ngraph_tf_cmake_flags.extend(
+            ["-DNGRAPH_TF_USE_GRAPPLER_OPTIMIZER=FALSE"])
 
     # Now build the bridge
-    ng_tf_whl = build_ngraph_tf(build_dir, artifacts_location, ngraph_tf_src_dir, venv_dir,
+    ng_tf_whl = build_ngraph_tf(build_dir, artifacts_location,
+                                ngraph_tf_src_dir, venv_dir,
                                 ngraph_tf_cmake_flags, verbosity)
 
     print("SUCCESSFULLY generated wheel: %s" % ng_tf_whl)
@@ -247,6 +281,7 @@ def main():
     # Run a quick test
     install_ngraph_tf(venv_dir, os.path.join(artifacts_location, ng_tf_whl))
 
+    print('\033[1;32mBuild successful\033[0m')
     os.chdir(pwd)
 
 

--- a/build_ngtf.py
+++ b/build_ngtf.py
@@ -118,7 +118,7 @@ def main():
 
     pwd = os.getcwd()
     ngraph_tf_src_dir = os.path.abspath(pwd)
-
+    build_dir_abs = os.path.abspath(build_dir)
     os.chdir(build_dir)
 
     venv_dir = 'venv-tf-py3'
@@ -166,12 +166,12 @@ def main():
             print("Building TensorFlow")
             # Download TensorFlow
             download_repo("tensorflow",
-                        "https://github.com/tensorflow/tensorflow.git",
-                        tf_version)
+                          "https://github.com/tensorflow/tensorflow.git",
+                          tf_version)
 
             # Build TensorFlow
             build_tensorflow(venv_dir, "tensorflow", artifacts_location,
-                            target_arch, verbosity)
+                             target_arch, verbosity)
 
             # Install tensorflow
             # Note that if gcc 4.8 is used for building TensorFlow this flag
@@ -182,7 +182,7 @@ def main():
             print('Version information:')
             print('TensorFlow version: ', tf.__version__)
             print('C Compiler version used in building TensorFlow: ',
-                tf.__compiler_version__)
+                  tf.__compiler_version__)
             cxx_abi = str(tf.__cxx11_abi_flag__)
 
     # Download nGraph
@@ -277,6 +277,14 @@ def main():
                                 ngraph_tf_cmake_flags, verbosity)
 
     print("SUCCESSFULLY generated wheel: %s" % ng_tf_whl)
+    print("PWD: " + os.getcwd())
+
+    # Copy the TensorFlow Python code tree to artifacts directory so that they can
+    # be used for running TensorFlow Python unit tests
+    command_executor([
+        'cp', '-r', build_dir_abs + '/tensorflow/tensorflow/python',
+        os.path.join(artifacts_location, "tensorflow")
+    ])
 
     # Run a quick test
     install_ngraph_tf(venv_dir, os.path.join(artifacts_location, ng_tf_whl))

--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -36,24 +36,8 @@ else
     SED_FLAGS='-rn'
 fi
 
-# Find out python version. Use yapf only when in Python 3
-if PYTHON_VERSION=$(python -c 'import sys; print(sys.version_info[:][0])')
-then
-    if [[ "3" != "${PYTHON_VERSION}" ]]; then
-        echo "Python reports version number '${PYTHON_VERSION}' so will skip yapf formatting. Please use Python3"
-    fi
-else
-    bash_lib_print_error "Failed invocation of Python."
-    exit 1
-fi
-
-
 declare CLANG_FORMAT_BASENAME="clang-format-3.9"
 declare REQUIRED_CLANG_FORMAT_VERSION=3.9
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    declare YAPF_FORMAT_BASENAME="yapf"
-    declare REQUIRED_YAPF_FORMAT_VERSION=0.26
-fi
 
 declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -65,19 +49,8 @@ if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
     bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
 fi
 
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    declare YAPF_FORMAT_PROG
-    if ! YAPF_FORMAT_PROG="$(which "${YAPF_FORMAT_BASENAME}")"; then
-        bash_lib_die "Unable to find program ${YAPF_FORMAT_BASENAME}" >&2
-    fi
-fi
-
 format_lib_verify_version "${CLANG_FORMAT_PROG}" "${REQUIRED_CLANG_FORMAT_VERSION}" "CLANG"
 bash_lib_status "Verified that '${CLANG_FORMAT_PROG}' has version '${REQUIRED_CLANG_FORMAT_VERSION}'"
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    format_lib_verify_version "${YAPF_FORMAT_PROG}" "${REQUIRED_YAPF_FORMAT_VERSION}" "YAPF"
-    bash_lib_status "Verified that '${YAPF_FORMAT_PROG}' has version '${REQUIRED_YAPF_FORMAT_VERSION}'"
-fi
 
 pushd "${THIS_SCRIPT_DIR}/.."
 
@@ -88,7 +61,7 @@ for ROOT_SUBDIR in ${SRC_DIRS}; do
     if ! [[ -d "${ROOT_SUBDIR}" ]]; then
 	    bash_lib_status "In directory '$(pwd)', no subdirectory named '${ROOT_SUBDIR}' was found."
     else
-        bash_lib_status "About to format C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
+        bash_lib_status "Formatting C/C++ code in: '$(pwd)/${ROOT_SUBDIR}'"
 
         # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
         # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
@@ -102,20 +75,15 @@ for ROOT_SUBDIR in ${SRC_DIRS}; do
                              -or -name '*.cpp' -or -name '*.hpp' \) \
              -print \) | xargs "${CLANG_FORMAT_PROG}" -i -style=file
 
-        bash_lib_status "Done."
-
-        if [[ "3" == "${PYTHON_VERSION}" ]]; then
-            bash_lib_status "About to format Python code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
-            declare SRC_FILE
-            # ignore the .in.py file (python/setup.in.py) which has format that crashes yapf
-            for SRC_FILE in $(find "${ROOT_SUBDIR}"                                      \
-                            -name *.in.py -prune -o                                   \
-                            \( -type f -and \( -name '*.py' \)                        \
-                                -print \) ); do
-                "${YAPF_FORMAT_PROG}"  -i -p --style google --no-local-style "${SRC_FILE}"
-            done
-            bash_lib_status "Done."
-        fi
+        bash_lib_status "Formatting Python code in: '$(pwd)/${ROOT_SUBDIR}' ..."
+        declare SRC_FILE
+        # ignore the .in.py file (python/setup.in.py) which has format that crashes yapf
+        for SRC_FILE in $(find "${ROOT_SUBDIR}"                                      \
+                        -name *.in.py -prune -o                                   \
+                        \( -type f -and \( -name '*.py' \)                        \
+                            -print \) ); do
+            python3 -m yapf -i -p --style google --no-local-style "${SRC_FILE}"
+        done
     fi
 done
 

--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -41,13 +41,13 @@ declare REQUIRED_CLANG_FORMAT_VERSION=3.9
 declare YAPF_FORMAT_BASENAME="yapf"
 declare REQUIRED_YAPF_FORMAT_VERSION=0.26.0
 
-# Check the YAPH format
-declare YAPH_VERSION=`python -c "import yapf; print(yapf.__version__)"`
+# Check the YAPF format
+declare YAPF_VERSION=`python -c "import yapf; print(yapf.__version__)"`
 
-if [[ "${YAPH_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
+if [[ "${YAPF_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
     echo -n "Unable to match version for ${YAPF_FORMAT_BASENAME}"
     echo -n " Required: ${REQUIRED_YAPF_FORMAT_VERSION}"
-    echo  " Installed: ${YAPH_VERSION}"
+    echo  " Installed: ${YAPF_VERSION}"
     exit -1
 fi
 

--- a/maint/apply-code-format.sh
+++ b/maint/apply-code-format.sh
@@ -38,6 +38,20 @@ fi
 
 declare CLANG_FORMAT_BASENAME="clang-format-3.9"
 declare REQUIRED_CLANG_FORMAT_VERSION=3.9
+declare YAPF_FORMAT_BASENAME="yapf"
+declare REQUIRED_YAPF_FORMAT_VERSION=0.26.0
+
+# Check the YAPH format
+declare YAPH_VERSION=`python -c "import yapf; print(yapf.__version__)"`
+
+if [[ "${YAPH_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
+    echo -n "Unable to match version for ${YAPF_FORMAT_BASENAME}"
+    echo -n " Required: ${REQUIRED_YAPF_FORMAT_VERSION}"
+    echo  " Installed: ${YAPH_VERSION}"
+    exit -1
+fi
+
+declare YAPF_FORMAT_PROG="python3 -m ${YAPF_FORMAT_BASENAME}"
 
 declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/maint/check-code-format.sh
+++ b/maint/check-code-format.sh
@@ -40,7 +40,17 @@ fi
 declare CLANG_FORMAT_BASENAME="clang-format-3.9"
 declare REQUIRED_CLANG_FORMAT_VERSION=3.9
 declare YAPF_FORMAT_BASENAME="yapf"
-declare REQUIRED_YAPF_FORMAT_VERSION=0.26
+declare REQUIRED_YAPF_FORMAT_VERSION=0.26.0
+
+# Check the YAPH format
+declare YAPH_VERSION=`python -c "import yapf; print(yapf.__version__)"`
+
+if [[ "${YAPH_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
+    echo -n "Unable to match version for ${YAPF_FORMAT_BASENAME}"
+    echo -n " Required: ${REQUIRED_YAPF_FORMAT_VERSION}"
+    echo  " Installed: ${YAPH_VERSION}"
+    exit -1
+fi
 
 declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -49,7 +59,7 @@ source "${THIS_SCRIPT_DIR}/clang_format_lib.sh"
 
 declare CLANG_FORMAT_PROG
 if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
-    bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
+    bash_lib_die "Unable to find program  ${CLANG_FORMAT_BASENAME}" >&2
 fi
 
 declare YAPF_FORMAT_PROG="python3 -m ${YAPF_FORMAT_BASENAME}"

--- a/maint/check-code-format.sh
+++ b/maint/check-code-format.sh
@@ -42,13 +42,13 @@ declare REQUIRED_CLANG_FORMAT_VERSION=3.9
 declare YAPF_FORMAT_BASENAME="yapf"
 declare REQUIRED_YAPF_FORMAT_VERSION=0.26.0
 
-# Check the YAPH format
-declare YAPH_VERSION=`python -c "import yapf; print(yapf.__version__)"`
+# Check the YAPF format
+declare YAPF_VERSION=`python -c "import yapf; print(yapf.__version__)"`
 
-if [[ "${YAPH_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
+if [[ "${YAPF_VERSION}" != "${REQUIRED_YAPF_FORMAT_VERSION}" ]] ; then
     echo -n "Unable to match version for ${YAPF_FORMAT_BASENAME}"
     echo -n " Required: ${REQUIRED_YAPF_FORMAT_VERSION}"
-    echo  " Installed: ${YAPH_VERSION}"
+    echo  " Installed: ${YAPF_VERSION}"
     exit -1
 fi
 

--- a/maint/check-code-format.sh
+++ b/maint/check-code-format.sh
@@ -37,23 +37,10 @@ else
     SED_FLAGS='-rn'
 fi
 
-# Find out python version. Use yapf only when in Python 3
-if PYTHON_VERSION=$(python -c 'import sys; print(sys.version_info[:][0])')
-then
-    if [[ "3" != "${PYTHON_VERSION}" ]]; then
-        echo "Python reports version number '${PYTHON_VERSION}' so will skip yapf formatting. Please use Python3"
-    fi
-else
-    bash_lib_print_error "Failed invocation of Python."
-    exit 1
-fi
-
 declare CLANG_FORMAT_BASENAME="clang-format-3.9"
 declare REQUIRED_CLANG_FORMAT_VERSION=3.9
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    declare YAPF_FORMAT_BASENAME="yapf"
-    declare REQUIRED_YAPF_FORMAT_VERSION=0.26
-fi
+declare YAPF_FORMAT_BASENAME="yapf"
+declare REQUIRED_YAPF_FORMAT_VERSION=0.26
 
 declare THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -65,23 +52,15 @@ if ! CLANG_FORMAT_PROG="$(which "${CLANG_FORMAT_BASENAME}")"; then
     bash_lib_die "Unable to find program ${CLANG_FORMAT_BASENAME}" >&2
 fi
 
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    declare YAPF_FORMAT_PROG
-    if ! YAPF_FORMAT_PROG="$(which "${YAPF_FORMAT_BASENAME}")"; then
-        bash_lib_die "Unable to find program ${YAPF_FORMAT_BASENAME}" >&2
-    fi
-fi
+declare YAPF_FORMAT_PROG="python3 -m ${YAPF_FORMAT_BASENAME}"
 
 format_lib_verify_version "${CLANG_FORMAT_PROG}" "${REQUIRED_CLANG_FORMAT_VERSION}" "CLANG"
 bash_lib_status "Verified that '${CLANG_FORMAT_PROG}' has version '${REQUIRED_CLANG_FORMAT_VERSION}'"
 declare -a FAILED_FILES_CLANG=()
 declare NUM_FILES_CHECKED_CLANG=0
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    format_lib_verify_version "${YAPF_FORMAT_PROG}" "${REQUIRED_YAPF_FORMAT_VERSION}" "YAPF"
-    bash_lib_status "Verified that '${YAPF_FORMAT_PROG}' has version '${REQUIRED_YAPF_FORMAT_VERSION}'"
-    declare -a FAILED_FILES_YAPF=()
-    declare NUM_FILES_CHECKED_YAPF=0
-fi
+
+declare -a FAILED_FILES_YAPF=()
+declare NUM_FILES_CHECKED_YAPF=0
 
 pushd "${THIS_SCRIPT_DIR}/.."
 
@@ -90,7 +69,7 @@ for ROOT_SUBDIR in ${SRC_DIRS}; do
     if ! [[ -d "${ROOT_SUBDIR}" ]]; then
         bash_lib_status "In directory '$(pwd)', no subdirectory named '${ROOT_SUBDIR}' was found."
     else
-        bash_lib_status "About to check formatting of C/C++ code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
+        bash_lib_status "Checking C/C++ formatting in directory: '$(pwd)/${ROOT_SUBDIR}' "
         declare SRC_FILE
         # Note that we restrict to "-type f" to exclude symlinks. Emacs sometimes
         # creates dangling symlinks with .cpp/.hpp suffixes as a sort of locking
@@ -109,20 +88,18 @@ for ROOT_SUBDIR in ${SRC_DIRS}; do
             NUM_FILES_CHECKED_CLANG=$((NUM_FILES_CHECKED_CLANG+1))
         done
 
-        if [[ "3" == "${PYTHON_VERSION}" ]]; then
-            bash_lib_status "About to check formatting of Python code in directory tree '$(pwd)/${ROOT_SUBDIR}' ..."
-            declare SRC_FILE
-            # ignore the .in.py file (python/setup.in.py) which has format that crashes yapf
-            for SRC_FILE in $(find "${ROOT_SUBDIR}"                                      \
-                            -name *.in.py -prune -o                                   \
-                            \( -type f -and \( -name '*.py' \)                        \
-                                -print \) ); do
-                if ! "${YAPF_FORMAT_PROG}"  -d -p --style google --no-local-style "${SRC_FILE}" >/dev/null; then
-                    FAILED_FILES_YAPF+=( "${SRC_FILE}" )
-                fi
-                NUM_FILES_CHECKED_YAPF=$((NUM_FILES_CHECKED_YAPF+1))
-            done
-        fi
+        bash_lib_status "Checking Python formatting in directory:  '$(pwd)/${ROOT_SUBDIR}'"
+        declare SRC_FILE
+        # ignore the .in.py file (python/setup.in.py) which has format that crashes yapf
+        for SRC_FILE in $(find "${ROOT_SUBDIR}"                                      \
+                        -name *.in.py -prune -o                                   \
+                        \( -type f -and \( -name '*.py' \)                        \
+                            -print \) ); do
+            if ! python3 -m yapf  -d -p --style google --no-local-style "${SRC_FILE}" >/dev/null; then
+                FAILED_FILES_YAPF+=( "${SRC_FILE}" )
+            fi
+            NUM_FILES_CHECKED_YAPF=$((NUM_FILES_CHECKED_YAPF+1))
+        done
     fi
 done
 
@@ -139,15 +116,13 @@ else
     exit 1
 fi
 
-if [[ "3" == "${PYTHON_VERSION}" ]]; then
-    if [[ ${#FAILED_FILES_YAPF[@]} -eq 0 ]]; then
-        bash_lib_status "All ${NUM_FILES_CHECKED_YAPF}  Python files pass the code-format check."
-    else
-        echo "${#FAILED_FILES_YAPF[@]} of ${NUM_FILES_CHECKED_YAPF} source files failed the code-format check:"
-        declare FAILED_SRC_FILE
-        for FAILED_SRC_FILE in ${FAILED_FILES_YAPF[@]}; do
-            echo "    ${FAILED_SRC_FILE}"
-        done
-        exit 1
-    fi
+if [[ ${#FAILED_FILES_YAPF[@]} -eq 0 ]]; then
+    bash_lib_status "All ${NUM_FILES_CHECKED_YAPF}  Python files pass the code-format check."
+else
+    echo "${#FAILED_FILES_YAPF[@]} of ${NUM_FILES_CHECKED_YAPF} source files failed the code-format check:"
+    declare FAILED_SRC_FILE
+    for FAILED_SRC_FILE in ${FAILED_FILES_YAPF[@]}; do
+        echo "    ${FAILED_SRC_FILE}"
+    done
+    exit 1
 fi

--- a/python/CreatePipWhl.cmake
+++ b/python/CreatePipWhl.cmake
@@ -46,6 +46,12 @@ if (PYTHON)
     message(STATUS "LIB_SUFFIX: ${NGTF_INSTALL_DIR}/${LIB_SUFFIX}")
     file(GLOB NGRAPH_LIB_FILES "${NGTF_INSTALL_DIR}/${LIB_SUFFIX}/lib*")
 
+    # Copy the ngraph_bridge include from install
+    file(
+        COPY "${NGTF_INSTALL_DIR}/include" 
+        DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/python/ngraph_bridge"
+    )
+    
     # Copy the ngraph_bridge libraries from install
     foreach(DEP_FILE ${NGRAPH_LIB_FILES})
         get_filename_component(lib_file_real_path ${DEP_FILE} ABSOLUTE)

--- a/python/ngraph_bridge/__init__.in.py
+++ b/python/ngraph_bridge/__init__.in.py
@@ -114,6 +114,7 @@ ngraph_bridge_lib.ngraph_get_currently_set_backend_name.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_is_logging_placement.restype = ctypes.c_bool
 ngraph_bridge_lib.ngraph_tf_version.restype = ctypes.c_char_p
 ngraph_bridge_lib.ngraph_lib_version.restype = ctypes.c_char_p
+ngraph_bridge_lib.ngraph_tf_cxx11_abi_flag.restype = ctypes.c_int
 
 try:
     importlib.import_module('plaidml.settings')
@@ -186,4 +187,6 @@ def is_logging_placement():
 __version__ = \
   "nGraph bridge version: " + str(ngraph_bridge_lib.ngraph_tf_version()) + "\n" + \
   "nGraph version used for this build: " + str(ngraph_bridge_lib.ngraph_lib_version()) + "\n" + \
-  "TensorFlow version used for this build: " + TF_GIT_VERSION_BUILT_WITH
+  "TensorFlow version used for this build: " + TF_GIT_VERSION_BUILT_WITH + "\n" \
+  "CXX11_ABI flag used for this build: " + str(ngraph_bridge_lib.ngraph_tf_cxx11_abi_flag())
+

--- a/python/setup.in.py
+++ b/python/setup.in.py
@@ -52,6 +52,7 @@ setup(
     package_data=
     {
         'ngraph_bridge': [
+            "include/ngraph/*",
             @ngraph_libraries@ @license_files@ @licence_top_level@
         ],
     },

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,9 @@ endif()
 
 # Now create the Python pip package. The following variables are passed to the 
 # CreatePipWhl.cmake
+# CMake "install" target "CODE" will propagate these variables to the 
+# target "SCRIPT" so that the "SCRIPT" (in ths case CreatePipWhl.cmake)
+# So any variable that we need to propagate needs to be added here
 install(CODE "set(OS_VERSION ${OS_VERSION})")
 install(CODE "set(NGRAPH_INSTALL_DIR \"${NGRAPH_INSTALL_DIR}\")")
 install(CODE "set(NGTF_SRC_DIR \"${CMAKE_CURRENT_SOURCE_DIR}/../\")")

--- a/src/version.cc
+++ b/src/version.cc
@@ -47,5 +47,12 @@ namespace tensorflow {
 namespace ngraph_bridge {
 const char* ngraph_tf_version() { return (NG_TF_VERSION_STRING); }
 const char* ngraph_lib_version() { return get_ngraph_version_string(); }
+int ngraph_tf_cxx11_abi_flag() {
+#ifdef _GLIBCXX_USE_CXX11_ABI
+  return _GLIBCXX_USE_CXX11_ABI;
+#else
+  return 0;
+#endif
+}
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/src/version.h
+++ b/src/version.h
@@ -24,6 +24,11 @@ const char* ngraph_tf_version();
 
 // Returns the nGraph version this bridge was compiled with
 const char* ngraph_lib_version();
+
+// Returns the 0 if _GLIBCXX_USE_CXX11_ABI wasn't set by the
+// compiler (e.g., clang or gcc pre 4.8) or the value of the
+// _GLIBCXX_USE_CXX11_ABI set during the compilation time
+int ngraph_tf_cxx11_abi_flag();
 }
 }  // namespace ngraph_bridge
 }  // namespace tensorflow

--- a/test/ci/buildkite/test_runner.py
+++ b/test/ci/buildkite/test_runner.py
@@ -106,8 +106,8 @@ def main():
     elif (arguments.test_bazel_build):
         run_bazel_build()
     elif (arguments.test_tf_python):
-        run_tensorflow_pytests_from_artifacts('./', 'build_cmake/tensorflow',
-                                              False)
+        run_tensorflow_pytests_from_artifacts(
+            './', arguments.artifacts_dir + '/tensorflow/python', False)
     elif (arguments.test_resnet):
         batch_size = 128
         iterations = 10

--- a/test/ci/buildkite/test_runner.py
+++ b/test/ci/buildkite/test_runner.py
@@ -106,7 +106,8 @@ def main():
     elif (arguments.test_bazel_build):
         run_bazel_build()
     elif (arguments.test_tf_python):
-        raise Exception("TensorFlow Python tests are not yet supported")
+        run_tensorflow_pytests_from_artifacts('./', 'build_cmake/tensorflow',
+                                              False)
     elif (arguments.test_resnet):
         batch_size = 128
         iterations = 10

--- a/test_ngtf.py
+++ b/test_ngtf.py
@@ -27,6 +27,7 @@ from distutils.sysconfig import get_python_lib
 #from tools.build_utils import load_venv, command_executor
 from tools.test_utils import *
 
+
 def main():
     '''
     Tests nGraph-TensorFlow Python 3. This script needs to be run after 
@@ -62,19 +63,18 @@ def main():
         run_bazel_build_test(venv_dir, build_dir)
 
     # First run the C++ gtests
-    run_ngtf_gtests(build_dir,None)
+    run_ngtf_gtests(build_dir, None)
 
     # If the GPU tests are requested, then run them as well
     if (arguments.gpu_unit_tests_enable):
         os.environ['NGRAPH_TF_BACKEND'] = 'GPU'
         run_ngtf_gtests(
-            build_dir, 
+            build_dir,
             str("-ArrayOps.Quanti*:ArrayOps.Dequant*:BackendManager.BackendAssignment:"
-            "MathOps.AnyKeepDims:MathOps.AnyNegativeAxis:MathOps.AnyPositiveAxis:"
-            "MathOps.AllKeepDims:MathOps.AllNegativeAxis:MathOps.AllPositiveAxis:"
-            "NNOps.Qu*:NNOps.SoftmaxZeroDimTest*:"
-            "NNOps.SparseSoftmaxCrossEntropyWithLogits")
-        )
+                "MathOps.AnyKeepDims:MathOps.AnyNegativeAxis:MathOps.AnyPositiveAxis:"
+                "MathOps.AllKeepDims:MathOps.AllNegativeAxis:MathOps.AllPositiveAxis:"
+                "NNOps.Qu*:NNOps.SoftmaxZeroDimTest*:"
+                "NNOps.SparseSoftmaxCrossEntropyWithLogits"))
 
     os.environ['NGRAPH_TF_BACKEND'] = 'CPU'
 

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -348,7 +348,7 @@ def install_ngraph_tf(venv_dir, ngtf_pip_whl):
     command_executor(["pip", "install", "-U", ngtf_pip_whl])
 
     import tensorflow as tf
-    print('Version information:')
+    print('\033[1;34mVersion information\033[0m')
     print('TensorFlow version: ', tf.__version__)
     print('C Compiler version used in building TensorFlow: ',
           tf.__compiler_version__)

--- a/tools/test_utils.py
+++ b/tools/test_utils.py
@@ -204,6 +204,57 @@ def run_tensorflow_pytests(venv_dir, build_dir, ngraph_tf_src_dir, tf_src_dir):
     os.chdir(root_pwd)
 
 
+def run_tensorflow_pytests_from_artifacts(ngraph_tf_src_dir, tf_src_dir,
+                                          xml_output):
+    root_pwd = os.getcwd()
+
+    ngraph_tf_src_dir = os.path.abspath(ngraph_tf_src_dir)
+
+    patch_file = os.path.abspath(
+        os.path.join(ngraph_tf_src_dir,
+                     "test/python/tensorflow/tf_unittest_ngraph.patch"))
+
+    # Next patch the TensorFlow so that the tests run using ngraph_bridge
+    pwd = os.getcwd()
+
+    # Go to the location of TesorFlow install directory
+    import tensorflow as tf
+    tf_dir = tf.sysconfig.get_lib()
+    os.chdir(os.path.join(tf_dir, '../'))
+    print("CURRENT DIR: " + os.getcwd())
+
+    print("Patching TensorFlow using: %s" % patch_file)
+    result = call(["patch", "-p1", "-N", "-i", patch_file])
+    print("Patch result: %d" % result)
+    os.chdir(pwd)
+
+    # Now run the TensorFlow python tests
+    test_src_dir = os.path.join(ngraph_tf_src_dir, "test/python/tensorflow")
+    test_script = os.path.join(test_src_dir, "tf_unittest_runner.py")
+    test_manifest_file = os.path.join(test_src_dir, "python_tests_list.txt")
+    test_xml_report = './junit_tensorflow_tests.xml'
+
+    import psutil
+    num_cores = int(psutil.cpu_count(logical=False))
+    print("OMP_NUM_THREADS: %s " % str(num_cores))
+    os.environ['OMP_NUM_THREADS'] = str(num_cores)
+    os.environ['NGRAPH_TF_DISABLE_DEASSIGN_CLUSTERS'] = '1'
+
+    cmd = [
+        "python",
+        test_script,
+        "--tensorflow_path",
+        tf_src_dir,
+        "--run_tests_from_file",
+        test_manifest_file,
+    ]
+    if xml_output:
+        cmd.extend(["--xml_report", test_xml_report])
+    command_executor(cmd)
+
+    os.chdir(root_pwd)
+
+
 def run_resnet50(build_dir):
 
     root_pwd = os.getcwd()


### PR DESCRIPTION
* Added support for including nGraph include files to the Python Whl so that other backends can be built with the binary distribution of `ngraph_tensorflow_bridge`.
* Modified the Python format checking/applying code
* Added API: `ngraph_tf_cxx11_abi_flag()` that returns the value of the `_GLIBCXX_USE_CXX11_ABI` used building the bridge and nGraph library. This will be useful for building other C++ libraries using the bridge (such as a backend).