### PR TITLE
Fix python2 docker builds given changes in code-format checks

### DIFF
--- a/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
+++ b/test/ci/docker/docker-scripts/run-ngraph-tf-build.sh
@@ -150,14 +150,6 @@ echo ' '
 echo 'Ubuntu version is:'
 cat /etc/os-release
 
-xtime="$(date)"
-echo  ' '
-echo  "===== Starting nGraph TensorFlow Bridge Source Code Format Check at ${xtime} ====="
-echo  ' '
-
-cd "${bridge_dir}"
-maint/check-code-format.sh
-
 # Make sure the Bazel cache is in /tmp, as docker images have too little space
 # in the root filesystem, where /home (and $HOME/.cache) is.  Even though we
 # may not be using the Bazel cache in the builds (in docker), we do this anyway

--- a/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
+++ b/test/ci/docker/dockerfiles/Dockerfile.ngraph-tf-ci-py2
@@ -19,6 +19,7 @@
 FROM ubuntu:16.04
 
 # Default python environment is python 2, thus python-pip and virtualenv
+# python3-* packages are needed for the code-format check, which uses python3
 # python-numpy, python-dev, and python-wheel all needed for TensorFlow build
 # git is needed to clone tensorflow repository
 # unzip and wget are needed for installing bazel
@@ -32,6 +33,7 @@ FROM ubuntu:16.04
 RUN apt-get update &&  apt-get install -y \
     python-pip virtualenv \
     python-numpy python-dev python-wheel \
+    python3-pip python3-numpy python3-dev python3-wheel \
     git \
     unzip wget \
     sudo \
@@ -62,6 +64,11 @@ RUN pip install keras_applications keras_preprocessing
 RUN pip install matplotlib librosa opencv-python
 RUN pip install yapf==0.26.0
 RUN pip install futures
+
+# yapf and futures are needed for code-format checks
+RUN pip3 install yapf==0.26.0
+RUN pip3 install futures
+
 
 # We include pytest so the Docker image can be used for daily validation
 RUN pip install --upgrade pytest


### PR DESCRIPTION
Modifications to get python2 builds (in docker) working again, given how code-format checks have been modified.  Formal code-format check removed from python2 build script because there is now a separate code-format check build task in CI, plus run-premerge-ci-checks.sh runs the code-format check.

Note: this also needs to get into the `r0.12` branch, as daily-builds (which are running off `r0.12`) are currently failing the python2 build task.